### PR TITLE
fix: check env vars before Secrets Manager in get_elasticsearch_credentials()

### DIFF
--- a/nui_shared_utils/es_client.py
+++ b/nui_shared_utils/es_client.py
@@ -52,14 +52,14 @@ class ElasticsearchClient(BaseClient, ServiceHealthMixin):
     def _resolve_credentials_from_env(self) -> Optional[Dict[str, Any]]:
         """Resolve Elasticsearch credentials from environment variables.
 
-        Checks for ES_PASSWORD (required to trigger).
-        ES_USERNAME defaults to "elastic" if not set.
+        Accepts both conventions: ES_PASSWORD/ES_USERNAME and ES_PASS/ES_USER.
+        Password is required to trigger. Username defaults to "elastic".
         """
-        password = os.environ.get("ES_PASSWORD")
+        password = os.environ.get("ES_PASSWORD") or os.environ.get("ES_PASS")
         if not password:
             return None
         return {
-            "username": os.environ.get("ES_USERNAME", "elastic"),
+            "username": os.environ.get("ES_USERNAME") or os.environ.get("ES_USER") or "elastic",
             "password": password,
         }
 

--- a/nui_shared_utils/secrets_helper.py
+++ b/nui_shared_utils/secrets_helper.py
@@ -112,13 +112,29 @@ def get_elasticsearch_credentials(secret_name: Optional[str] = None) -> Dict:
     """
     Get Elasticsearch credentials.
 
+    Precedence (matching BaseServiceClient pattern):
+    1. Environment variables (ES_PASSWORD/ES_PASS + ES_USERNAME/ES_USER)
+    2. AWS Secrets Manager
+
     Args:
-        secret_name: Override default from configuration or environment
+        secret_name: Override default secret name for Secrets Manager lookup.
+            Ignored when credentials are resolved from environment variables.
 
     Returns:
         Dict with host, username, password
     """
     config = get_config()
+
+    # Environment variables first (local dev, CLI usage)
+    es_password = os.environ.get("ES_PASSWORD") or os.environ.get("ES_PASS")
+    if es_password:
+        es_user = os.environ.get("ES_USERNAME") or os.environ.get("ES_USER") or "elastic"
+        host = os.environ.get("ES_HOST") or config.es_host
+        if ":" not in host and not host.startswith("http"):
+            host = f"{host}:9200"
+        return {"host": host, "username": es_user, "password": es_password}
+
+    # Secrets Manager (Lambda runtime)
     secret = secret_name or os.environ.get("ES_CREDENTIALS_SECRET") or config.es_credentials_secret
     if not secret:
         raise ValueError("No Elasticsearch secret name provided")

--- a/tests/test_es_client.py
+++ b/tests/test_es_client.py
@@ -502,6 +502,17 @@ class TestElasticsearchCredentialResolution:
 
     @patch("nui_shared_utils.base_client.get_secret")
     @patch("nui_shared_utils.es_client.Elasticsearch")
+    @patch.dict("os.environ", {"ES_PASS": "short-pass", "ES_USER": "short-user"}, clear=True)
+    def test_env_var_short_form(self, mock_es, mock_get_secret):
+        """ES_PASS/ES_USER convention also works."""
+        client = ElasticsearchClient()
+
+        mock_get_secret.assert_not_called()
+        assert client.credentials["password"] == "short-pass"
+        assert client.credentials["username"] == "short-user"
+
+    @patch("nui_shared_utils.base_client.get_secret")
+    @patch("nui_shared_utils.es_client.Elasticsearch")
     @patch.dict("os.environ", {"ES_PASSWORD": "env-pass"}, clear=False)
     def test_explicit_credentials_win_over_env_vars(self, mock_es, mock_get_secret):
         """Explicit credentials should take priority over env vars."""

--- a/tests/test_secrets_helper.py
+++ b/tests/test_secrets_helper.py
@@ -228,6 +228,43 @@ class TestGetElasticsearchCredentials:
         assert "No Elasticsearch secret name provided" in str(exc_info.value)
 
 
+    @patch.dict("os.environ", {"ES_PASSWORD": "env_pass", "ES_USERNAME": "env_user", "ES_HOST": "env-host:9200"}, clear=True)
+    def test_get_elasticsearch_credentials_env_vars_first(self, mock_secrets_manager):
+        """Env vars take precedence over Secrets Manager."""
+        result = secrets_helper.get_elasticsearch_credentials("es-secret")
+
+        assert result == {"host": "env-host:9200", "username": "env_user", "password": "env_pass"}
+        mock_secrets_manager.get_secret_value.assert_not_called()
+
+    @patch.dict("os.environ", {"ES_PASS": "env_pass2", "ES_USER": "env_user2", "ES_HOST": "env-host:9200"}, clear=True)
+    def test_get_elasticsearch_credentials_short_env_vars(self, mock_secrets_manager):
+        """ES_PASS/ES_USER convention also works."""
+        result = secrets_helper.get_elasticsearch_credentials()
+
+        assert result == {"host": "env-host:9200", "username": "env_user2", "password": "env_pass2"}
+        mock_secrets_manager.get_secret_value.assert_not_called()
+
+    @patch.dict("os.environ", {"ES_PASSWORD": "env_pass"}, clear=True)
+    @patch("nui_shared_utils.secrets_helper.get_config")
+    def test_get_elasticsearch_credentials_partial_env_vars(self, mock_get_config):
+        """Password-only env var works, username defaults to 'elastic'."""
+        mock_config = Mock()
+        mock_config.es_host = "default-host"
+        mock_get_config.return_value = mock_config
+
+        result = secrets_helper.get_elasticsearch_credentials()
+
+        assert result == {"host": "default-host:9200", "username": "elastic", "password": "env_pass"}
+
+    @patch.dict("os.environ", {"ES_PASSWORD": "env_pass", "ES_HOST": "env-host:9200"}, clear=True)
+    def test_get_elasticsearch_credentials_env_vars_override_secret_name(self, mock_secrets_manager):
+        """Env vars win even when secret_name is explicitly passed."""
+        result = secrets_helper.get_elasticsearch_credentials(secret_name="my-specific-secret")
+
+        assert result["password"] == "env_pass"
+        mock_secrets_manager.get_secret_value.assert_not_called()
+
+
 class TestGetSlackCredentials:
     """Tests for get_slack_credentials function."""
 


### PR DESCRIPTION
## Summary
- `get_elasticsearch_credentials()` now checks `ES_PASSWORD`/`ES_PASS` env vars before hitting Secrets Manager, aligning with the `BaseServiceClient` credential precedence (env > SM)
- `ESClient._resolve_credentials_from_env()` updated to also accept `ES_PASS`/`ES_USER` (short-form convention used by CLI tools and credentials unlock)
- No behavioral change in Lambda (those env vars aren't set there)

## Backwards compatibility
- Callers that don't set `ES_PASSWORD`/`ES_PASS` env vars see no change (Secrets Manager path unchanged)
- Callers that do set env vars get faster credential resolution without SM calls

## Review
- P1 (bugs/correctness): clean
- P2 (polish): 3 auto-fixed (hoisted `get_config()`, dropped numbered comments, cleaner test isolation)

## Changes
```
 nui_shared_utils/secrets_helper.py  | +17 -1
 nui_shared_utils/es_client.py       | +4 -4
 tests/test_secrets_helper.py        | +37
 tests/test_es_client.py             | +11
```

## Test plan
- [x] Env vars present: returns env-var creds, SM not called
- [x] Short-form env vars (ES_PASS/ES_USER): works identically
- [x] Partial env vars (password only): username defaults to "elastic"
- [x] Env vars override explicit secret_name param
- [x] No env vars: falls through to SM (existing behavior preserved)
- [x] ESClient short-form env vars (ES_PASS/ES_USER)
- [x] Full suite: 57 tests passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Elasticsearch credential resolution now supports both standard (ES_PASSWORD/ES_USERNAME) and alternative (ES_PASS/ES_USER) environment variable naming conventions with clear precedence.
  * Environment variables now take precedence over AWS Secrets Manager for credential resolution.

* **Tests**
  * Added comprehensive test coverage for credential resolution scenarios and precedence behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->