### PR TITLE
fix(secrets): respect AWS_REGION for secret lookups

### DIFF
--- a/nui_shared_utils/secrets_helper.py
+++ b/nui_shared_utils/secrets_helper.py
@@ -38,7 +38,11 @@ def get_secret(secret_name: str) -> Dict:
 
     # Create a Secrets Manager client
     session = boto3.session.Session()
-    client = session.client(service_name="secretsmanager", region_name=session.region_name or "ap-southeast-2")
+    region = session.region_name or os.environ.get("AWS_REGION") or os.environ.get("AWS_DEFAULT_REGION")
+    if not region:
+        raise Exception("AWS region not configured for Secrets Manager lookup; set AWS_REGION or AWS_DEFAULT_REGION")
+
+    client = session.client(service_name="secretsmanager", region_name=region)
 
     try:
         response = client.get_secret_value(SecretId=secret_name)

--- a/tests/test_secrets_helper.py
+++ b/tests/test_secrets_helper.py
@@ -26,6 +26,28 @@ class TestGetSecret:
         }
         mock_secrets_manager.get_secret_value.assert_called_once_with(SecretId="test-secret")
 
+    @pytest.mark.unit
+    def test_get_secret_uses_aws_region_when_session_region_missing(self, mock_boto3_session, mock_secrets_manager):
+        """Test AWS_REGION fallback when boto3 session has no region."""
+        mock_boto3_session.region_name = None
+
+        with patch.dict(os.environ, {"AWS_REGION": "eu-west-1"}, clear=True):
+            secrets_helper.get_secret("test-secret")
+
+        mock_boto3_session.client.assert_called_once_with(service_name="secretsmanager", region_name="eu-west-1")
+
+    @pytest.mark.unit
+    def test_get_secret_requires_region_when_session_and_env_missing(self, mock_boto3_session):
+        """Test clear error when no Secrets Manager region is configured."""
+        mock_boto3_session.region_name = None
+
+        with patch.dict(os.environ, {}, clear=True):
+            with pytest.raises(Exception) as exc_info:
+                secrets_helper.get_secret("test-secret")
+
+        assert "AWS region not configured for Secrets Manager lookup" in str(exc_info.value)
+        mock_boto3_session.client.assert_not_called()
+
     def test_get_secret_cached(self, mock_secrets_manager):
         """Test that secrets are cached after first retrieval."""
         # First call
@@ -227,8 +249,9 @@ class TestGetElasticsearchCredentials:
 
         assert "No Elasticsearch secret name provided" in str(exc_info.value)
 
-
-    @patch.dict("os.environ", {"ES_PASSWORD": "env_pass", "ES_USERNAME": "env_user", "ES_HOST": "env-host:9200"}, clear=True)
+    @patch.dict(
+        "os.environ", {"ES_PASSWORD": "env_pass", "ES_USERNAME": "env_user", "ES_HOST": "env-host:9200"}, clear=True
+    )
     def test_get_elasticsearch_credentials_env_vars_first(self, mock_secrets_manager):
         """Env vars take precedence over Secrets Manager."""
         result = secrets_helper.get_elasticsearch_credentials("es-secret")


### PR DESCRIPTION
## Summary
- Make Secrets Manager region resolution honor `AWS_REGION` when boto3 has no session region.
- Remove the silent `ap-southeast-2` fallback so missing region config fails with an explicit error.
- Cover the local-run fallback and missing-region failure paths in `secrets_helper` tests.

## Review
- Internal: clean, no findings in the committed diff.
- External: Kimi review was not run because tenant policy rejected sending private repo diff/file contents to an external service.
- Static analysis: `ruff check nui_shared_utils/secrets_helper.py tests/test_secrets_helper.py` reports pre-existing `F841` issues in `tests/test_secrets_helper.py` outside this change.

## Changes
- `nui_shared_utils/secrets_helper.py`: resolve Secrets Manager region from boto3 session, `AWS_REGION`, then `AWS_DEFAULT_REGION`; raise a clear error if none is configured.
- `tests/test_secrets_helper.py`: add coverage for `AWS_REGION` fallback and missing-region failure.

## Test plan
- [x] `black nui_shared_utils/secrets_helper.py tests/test_secrets_helper.py`
- [x] `pytest tests/test_secrets_helper.py -q`
- [x] `pytest tests/test_slack_client.py::TestSendFile -q`
- [ ] `pytest -q` blocked locally by missing `snowflake-sql-api`; also shows two order-dependent Slack file-upload failures that pass in isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret retrieval to use the AWS region from the active session or environment variables, instead of relying on a fixed fallback region.
  * Added a clear error when no AWS region is available, helping prevent misconfigured secret lookups.

* **Tests**
  * Expanded test coverage for region fallback behavior and the no-region error case.
  * Updated formatting in existing environment-based test setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->