### PR TITLE
fix(deps): replace snowflake-sql-api git URL with PyPI version pin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,11 +45,10 @@ powertools = [
     "coloredlogs>=15.0",
 ]
 jwt = ["rsa>=4.9"]
-# Tag pin to the public snowflake-sql-api repo. Repin to a PyPI release once
-# that package is published. Kept out of `all` so nothing pulls the git
-# dependency implicitly.
+# Pinned to the published PyPI release (no direct-URL deps, PyPI rejects those
+# on upload). Kept out of `all`: opt-in.
 snowflake = [
-    "snowflake-sql-api @ git+https://github.com/hampsterx/snowflake-sql-api.git@v0.1.1",
+    "snowflake-sql-api>=0.1.1,<0.2.0",
 ]
 # Anthropic (Claude) helper. anthropic[bedrock] covers both auth modes (API key
 # + Bedrock IAM). Kept out of `all` (same as snowflake): the SDK is specialized
@@ -78,7 +77,7 @@ dev = [
     "build>=0.8.0",
     "rsa>=4.9",
     "cryptography>=41.0.0",
-    "snowflake-sql-api @ git+https://github.com/hampsterx/snowflake-sql-api.git@v0.1.1",
+    "snowflake-sql-api>=0.1.1,<0.2.0",
     "anthropic[bedrock]>=0.45.0,<1.0.0",
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -57,12 +57,10 @@ setup(
             "coloredlogs>=15.0",
         ],
         "jwt": ["rsa>=4.9"],
-        # Pre-release pin to the public snowflake-sql-api repo (PR #1 merge
-        # commit on master). Repinned to a PyPI release (>=0.1.0) once that
-        # package ships. Kept out of "all" so nothing pulls the git dep
-        # implicitly.
+        # Pinned to the published PyPI release (no direct-URL deps, PyPI rejects
+        # those on upload). Kept out of "all": opt-in.
         "snowflake": [
-            "snowflake-sql-api @ git+https://github.com/hampsterx/snowflake-sql-api.git@50205b0cb63df008c9c453ee05f0f130dcfe4805",
+            "snowflake-sql-api>=0.1.1,<0.2.0",
         ],
         # Anthropic (Claude) helper. anthropic[bedrock] covers both auth modes
         # (API key + Bedrock IAM). Kept out of "all" (same as snowflake): the


### PR DESCRIPTION
## Summary
- PyPI rejects package metadata containing direct-URL (`@ git+https`) dependencies. This blocked the 1.4.0 publish: the build succeeded but upload returned `400 Can't have direct dependency: snowflake-sql-api @ ...`, so 1.4.0 (including the new `[llm]` helper) never reached PyPI.
- `snowflake-sql-api` is now published on PyPI (0.1.1), so it can be pinned as a normal version requirement.
- Replaces the git reference with `snowflake-sql-api>=0.1.1,<0.2.0` in the `snowflake` and `dev` extras, across **both** `setup.py` and `pyproject.toml`. The two files had drifted (only `pyproject`'s `dev` extra carried the git dep); they are consistent now.

## Context
This was a pre-existing packaging bug introduced with the `snowflake` extra (PR #27), not the LLM helper (PR #28). 1.3.3 had no `snowflake` extra, so it published fine; 1.4.0 was the first release to carry the direct-URL dep in its metadata. A new tag (1.4.1) is needed to re-attempt publish after this merges.

## Test plan
- [x] `python -m build` succeeds (wheel + sdist)
- [x] `twine check dist/*` passes
- [x] Built wheel `METADATA` has no direct-URL `Requires-Dist` entries; snowflake-sql-api shows `Requires-Dist: snowflake-sql-api<0.2.0,>=0.1.1; extra == "snowflake"` (and `dev`)
- [ ] Tag 1.4.1 after merge, confirm the publish workflow uploads to PyPI