### PR TITLE
feat(slack): add unfurl_links/unfurl_media control to send_message

### DIFF
--- a/nui_shared_utils/slack_client.py
+++ b/nui_shared_utils/slack_client.py
@@ -388,7 +388,9 @@ class SlackClient(BaseClient, ServiceHealthMixin):
         blocks: Optional[List[Dict]] = None,
         attachments: Optional[List[Dict]] = None,
         include_lambda_header: bool = True,
-        event_type: Optional[str] = None
+        event_type: Optional[str] = None,
+        unfurl_links: Optional[bool] = None,
+        unfurl_media: Optional[bool] = None,
     ) -> bool:
         """
         Send message to Slack channel with standardized error handling.
@@ -400,6 +402,10 @@ class SlackClient(BaseClient, ServiceHealthMixin):
             attachments: Legacy attachment objects (supports color sidebars)
             include_lambda_header: Whether to include context header
             event_type: Optional event type label for header (e.g., "Scheduled", "API", "SQS")
+            unfurl_links: Override Slack link unfurling. None leaves Slack's default;
+                False suppresses link preview cards (links stay clickable)
+            unfurl_media: Override Slack media unfurling. None leaves Slack's default;
+                False suppresses media preview cards
 
         Returns:
             True if successful, False otherwise
@@ -419,12 +425,19 @@ class SlackClient(BaseClient, ServiceHealthMixin):
             else:
                 blocks_with_header = blocks
 
-            response = self._service_client.chat_postMessage(
+            kwargs = dict(
                 channel=channel,
                 text=text,
                 blocks=blocks_with_header,
-                attachments=attachments
+                attachments=attachments,
             )
+            # Forward unfurl controls only when explicitly set, so existing callers
+            # keep Slack's default behavior (and their call assertions stay unchanged).
+            if unfurl_links is not None:
+                kwargs["unfurl_links"] = unfurl_links
+            if unfurl_media is not None:
+                kwargs["unfurl_media"] = unfurl_media
+            response = self._service_client.chat_postMessage(**kwargs)
 
             if response["ok"]:
                 log.info(

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -113,6 +113,52 @@ class TestSendMessage:
 
     @patch("nui_shared_utils.base_client.get_secret")
     @patch("nui_shared_utils.slack_client.WebClient")
+    def test_send_message_forwards_unfurl_flags(self, mock_webclient, mock_get_secret):
+        """unfurl_links / unfurl_media are forwarded to chat_postMessage when set."""
+        mock_get_secret.return_value = {"bot_token": "xoxb-test-token"}
+        mock_client = Mock()
+        mock_webclient.return_value = mock_client
+        mock_client.chat_postMessage.return_value = {"ok": True, "ts": "1234567890.123456"}
+
+        slack = SlackClient(secret_name="test-secret")
+        result = slack.send_message(
+            "C123",
+            "Test message",
+            include_lambda_header=False,
+            unfurl_links=False,
+            unfurl_media=False,
+        )
+
+        assert result is True
+        mock_client.chat_postMessage.assert_called_once_with(
+            channel="C123",
+            text="Test message",
+            blocks=None,
+            attachments=None,
+            unfurl_links=False,
+            unfurl_media=False,
+        )
+
+    @patch("nui_shared_utils.base_client.get_secret")
+    @patch("nui_shared_utils.slack_client.WebClient")
+    def test_send_message_omits_unfurl_when_unset(self, mock_webclient, mock_get_secret):
+        """When the unfurl flags are unset (default None), they are NOT forwarded, so
+        Slack's default behavior is preserved for every existing caller."""
+        mock_get_secret.return_value = {"bot_token": "xoxb-test-token"}
+        mock_client = Mock()
+        mock_webclient.return_value = mock_client
+        mock_client.chat_postMessage.return_value = {"ok": True, "ts": "1234567890.123456"}
+
+        slack = SlackClient(secret_name="test-secret")
+        result = slack.send_message("C123", "Test message", include_lambda_header=False)
+
+        assert result is True
+        _, kwargs = mock_client.chat_postMessage.call_args
+        assert "unfurl_links" not in kwargs
+        assert "unfurl_media" not in kwargs
+
+    @patch("nui_shared_utils.base_client.get_secret")
+    @patch("nui_shared_utils.slack_client.WebClient")
     def test_send_message_api_error(self, mock_webclient, mock_get_secret):
         """Test handling of Slack API error."""
         mock_get_secret.return_value = {"bot_token": "xoxb-test-token"}


### PR DESCRIPTION
## Summary
- Callers can suppress Slack's link/media preview cards (e.g. a digest of many links that would otherwise unfurl into a wall of cards) while keeping the links themselves clickable.
- `SlackClient.send_message` gains optional `unfurl_links` / `unfurl_media` params (default `None`).
- Params are forwarded to `chat_postMessage` only when explicitly set, so every existing caller keeps Slack's default behavior.

## Backwards compatibility
- Additive optional params, default `None`. When both are unset, `chat_postMessage` is called with exactly `channel`/`text`/`blocks`/`attachments` (no unfurl keys), byte-for-byte the prior behavior. The `is not None` guard means `unfurl_links=False` is forwarded, not dropped by a truthiness check. A dedicated test locks in the omit-when-unset path.

## Review
- Internal: clean (verified the `is not None` guard forwards `False`).
- External (Codex, Kimi-agentic): both clean, no findings.

## Changes
- `nui_shared_utils/slack_client.py`: two optional params + conditional kwargs pass-through.
- `tests/test_slack_client.py`: forward-when-set and omit-when-unset tests.

## Test plan
- [x] Unit test: flags forwarded to `chat_postMessage` when set
- [x] Unit test: flags omitted when unset (default behavior preserved)
- [x] `test_slack_client.py` green (45 passed)
- [x] New additions Black-clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional controls for Slack message link and media unfurling, allowing messages to explicitly enable or disable this behavior.
  * When these options are not set, existing default Slack behavior is preserved.

* **Tests**
  * Added coverage to verify unfurl settings are passed through when provided and omitted when left unset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->