### PR TITLE
ci: dedup PyPI publish trigger and bump actions to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,15 +15,17 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     
     - name: Cache pip dependencies
-      uses: actions/cache@v3
+      uses: actions/cache@v6
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml', '**/setup.py') }}
@@ -65,9 +67,9 @@ jobs:
         pytest --cov=nui_shared_utils --cov-report=xml --cov-report=term-missing -v
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
@@ -78,10 +80,12 @@ jobs:
     needs: test
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,9 +3,7 @@ name: Build and Publish to PyPI
 on:
   push:
     tags:
-      - '[0-9]*'  # Trigger on version tags like 1.3.0
-  release:
-    types: [published]
+      - '[0-9]*'  # Trigger on version tags like 1.3.0 (a published GitHub Release also creates the tag)
   workflow_dispatch:  # Allow manual triggering
 
 jobs:
@@ -17,10 +15,12 @@ jobs:
         python-version: ['3.9', '3.10', '3.11', '3.12']
     
     steps:
-    - uses: actions/checkout@v4
-    
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     
@@ -41,9 +41,9 @@ jobs:
         pytest --cov=nui_shared_utils --cov-report=xml --cov-report=term-missing
     
     - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
-        file: ./coverage.xml
+        files: ./coverage.xml
         fail_ci_if_error: false
 
   build:
@@ -52,12 +52,13 @@ jobs:
     needs: test
     
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
+        persist-credentials: false
         fetch-depth: 0  # Full history for version calculation
     
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: '3.11'
     
@@ -75,7 +76,7 @@ jobs:
         python -m tarfile -l dist/*.tar.gz
     
     - name: Upload artifacts
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: dist
         path: dist/
@@ -85,7 +86,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test, build]
     # Only publish on tagged releases
-    if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/')
     environment:
       name: pypi
       url: https://pypi.org/project/nui-python-shared-utils/
@@ -96,7 +97,7 @@ jobs:
     
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: dist
         path: dist/
@@ -106,13 +107,14 @@ jobs:
       with:
         verbose: true
         print-hash: true
+        skip-existing: true  # No-op instead of failing if the version is already on PyPI (safe re-runs)
 
   publish-test:
     name: Publish to TestPyPI
     runs-on: ubuntu-latest
     needs: [test, build]
-    # Publish to TestPyPI on manual trigger or development branches
-    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && !startsWith(github.ref, 'refs/tags/'))
+    # Publish to TestPyPI on manual (non-tag) dispatch only; tag pushes go to PyPI above
+    if: github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')
     environment:
       name: testpypi
       url: https://test.pypi.org/project/nui-python-shared-utils/
@@ -123,7 +125,7 @@ jobs:
     
     steps:
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
       with:
         name: dist
         path: dist/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,12 @@ jobs:
         python-version: ['3.9', '3.10', '3.11']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
     
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     


### PR DESCRIPTION
## Summary

- Fix every GitHub Release showing a failed **Build and Publish to PyPI** run. The workflow fired on both `push: tags` and `release: published`; a published Release creates the tag, so both triggers launched a publish job, they raced, and the loser failed with `400 File already exists`. Drop the `release` trigger and keep `push: tags` (a published Release still creates the tag, and bare tag pushes like 1.4.1 keep working), plus add `skip-existing: true` as a re-run guard.
- Clear the Node 20 runtime deprecation warnings across all three workflows by bumping each action to its first Node 24 major: `checkout` v5, `setup-python` v6, `cache` v6, `upload-artifact` v6, `download-artifact` v7.
- Update `codecov-action` v3 → v5 with its breaking input rename `file:` → `files:` (v5 is a composite action, no Node runtime).
- Simplify the `publish-test` (TestPyPI) job to manual, non-tag `workflow_dispatch` only, removing a dead branch-push clause and preventing a manual dispatch on a tag ref from publishing to both PyPI and TestPyPI.
- Harden every `actions/checkout` step with `persist-credentials: false` so no writable git token is left on disk. None of these jobs push (the CI black-format step commits locally only), so nothing relies on the persisted credential.

## Review

Internal: 1 auto-fixed (dead TestPyPI clause). External (Codex + Kimi-agentic): 1 applied (dispatch-on-tag double-publish guard), no blocking issues. CodeRabbit: 3 `persist-credentials` nitpicks, all applied.

## Changes

```
 .github/workflows/ci.yml      | 18 +++++++++++-------
 .github/workflows/publish.yml | 34 ++++++++++++++++++----------------
 .github/workflows/test.yml    |  6 ++++--
 3 files changed, 33 insertions(+), 25 deletions(-)
```

## Test plan

- [x] All three workflow YAMLs parse (`yaml.safe_load`)
- [x] Every bumped action confirmed `node24` (or composite) via its `action.yml` `runs.using`
- [x] All pinned tags exist on the upstream action repos
- [x] Full CI matrix (Build + Test 3.9–3.12 on both workflows) green on the Node 24 actions
- [ ] Next tagged release produces exactly one publish run (no duplicate `400`)

## Backwards compatibility

No package or API changes. CI/release infrastructure only. Existing release flow is unchanged for maintainers: publishing a GitHub Release (or pushing a version tag) still publishes to PyPI, now via a single run instead of a racing pair.