### PR TITLE
feat(logging): structured logging field registry + binding helpers

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,6 +17,7 @@ Welcome to the comprehensive documentation for `nui-python-shared-utils` (former
 Component-specific guides for major features:
 
 - **[AWS Powertools Integration](guides/powertools-integration.md)** - Standardized logging, metrics, and error handling
+- **[Structured Logging Contract](guides/structured-logging-contract.md)** - Canonical dotted field registry, request-scoped binders, and payload redaction
 - **[Lambda Context Helpers](guides/lambda-utilities.md)** - Environment info extraction for logging and metrics
 - **[Slack Integration](guides/slack-integration.md)** - Messaging, formatting, and file uploads
 - **[Elasticsearch Integration](guides/elasticsearch-integration.md)** - Search, bulk indexing, health checks

--- a/docs/decisions/ADR-001-structured-logging-field-vocabulary.md
+++ b/docs/decisions/ADR-001-structured-logging-field-vocabulary.md
@@ -1,0 +1,108 @@
+# ADR-001: Structured logging field vocabulary
+
+**Status**: Proposed
+**Date**: 2026-07-11
+
+## Context
+
+This package is the shared logging entry point for a fleet of Python Lambda functions and
+long-running services whose structured logs are shipped to a central log store and queried by
+operators and automated agents. Reliable querying, dashboards, and alerting need a predictable
+field shape: consistent key names and stable leaf types across every producer.
+
+Today the logger helper (`get_powertools_logger`) sets service, level, timezone, and timestamp
+format, but takes no position on field names or shape. Each call site hand-assembles its own
+`extra={}` keys. Across the fleet this has grown several incompatible conventions in the same log
+stream: flat single-word keys (`order_id`), dotted namespaced keys (`request.order_id`), nested
+dicts (`extra={"request": {...}}`), and unstructured message strings.
+
+This is a **producer-side** problem, and its cost is independent of which store the logs land in:
+
+- A **schema-enforcing** store (Elasticsearch) turns field drift into loud failures: mapping
+  conflicts and silent nulls when `status` is a number in one document and a string in the next.
+- A **schema-less** store (VictoriaLogs, Loki) accepts the drift silently. `{"status": 200}` and
+  `{"status": "timeout"}` are both ingested with no error, and the skew surfaces later as a
+  dashboard panel or an alert rule (`5xx rate`, `exception spike`) that quietly stops matching.
+
+So the log store is deliberately out of scope for this decision (it is itself under evaluation),
+and the contract is **store-neutral**. The one property of the stack that does constrain the wire
+shape is producer-side:
+
+**The Powertools `Logger.append_keys` merge is shallow.** Binding context incrementally with
+nested dicts clobbers earlier keys: `append_keys(request={"a": 1})` then `append_keys(request={"b": 2})`
+emits `request={"b": 2}` and loses `a`. Dotted keys (`append_keys(**{"request.a": 1})`, then
+`request.b`) are independent top-level keys and both survive. (Confirmed on `aws-lambda-powertools`
+3.6.0.) Incremental binding (bind request at entry, add more later) therefore requires dotted keys.
+
+(Incidental, not load-bearing: while Elasticsearch is a store, it expands dotted field names into
+`object`-datatype paths at index time, so `request.order_id` and `{"request": {"order_id": ...}}`
+map and query identically. Wire shape does not change queryability there. A store swap does not
+disturb this decision because the decision does not rest on it.)
+
+## Decision
+
+This package owns a canonical **dotted** field vocabulary as the fleet's logging contract, defined
+independently of any log store:
+
+- **A field registry (schema object)**: one importable module where each canonical dotted field
+  carries its type, whether it is indexed (i.e. meant to be queried vs retrieval-only), a
+  sensitivity flag, and any deprecated aliases. Covers `request.*`, `user.*`, `route.*`,
+  `response.*`, `error.*`, `trace.*`, `request.body_json` / `response.output_json`, plus a `target`
+  routing field. Single source of truth from which the default redaction set and the field-migration
+  map are derived. (A plain `dataclass`, not a heavyweight model dependency: the registry is static
+  metadata.)
+- **Binding helpers** (`bind_request`, `bind_user`, `log_exception`, and a body helper that
+  serialises to a single `request.body_json` string with redaction) so callers never hand-type keys.
+- **A consistency test** that asserts the registry's names, importable so consumers guard against
+  drift in CI.
+- The vocabulary is **backend-agnostic**: consumed identically from the Powertools path and from a
+  standard-library JSON-formatter path, so short-lived functions and long-running services share one
+  contract.
+
+Wire shape is **dotted**, names are **snake_case** dotted paths. Nested-dict emission is not used.
+
+## Alternatives considered
+
+- **Nested dicts as the emitted shape.** Ergonomic to build in one call and natural in Python.
+  Rejected because it clobbers under incremental `append_keys` binding, and because the fleet's
+  existing namespaced emitters already use dotted. Nested-*feeling* ergonomics are kept: the binding
+  helpers take keyword args and emit dotted keys.
+- **Flat single-word keys** (`order_id`, `user_id`). Simplest, but no namespacing, so unrelated
+  fields collide and there is no structural grouping for operators or mappings.
+- **A per-repo constants module.** Two codebases independently grew partial dotted taxonomies, which
+  proves the convention is wanted, but a per-repo copy re-introduces drift. One shared registry is
+  the point.
+- **Bake the vocabulary into a single logger factory.** Cannot span the two logging backends in use,
+  so the contract lives in a backend-agnostic registry plus helpers rather than a factory.
+- **Defer the contract until the log store is chosen.** Rejected: the drift is producer-side and
+  costs the same under either candidate store. A store-neutral contract is the piece that survives
+  (and is required by) a store migration, not one that blocks on it. Under a schema-less store it is
+  the *only* drift guard, since nothing downstream rejects a malformed field.
+
+## Consequences
+
+- One field shape across the fleet; the cost of field-name/type drift (loud mapping conflicts on a
+  schema-enforcing store, silent query/alert skew on a schema-less one) goes away as consumers adopt
+  it.
+- `request.body_json` as one opaque, retrieval-only string keeps unbounded, caller-controlled payloads
+  from bloating the field set (a concern under any store, acute on a mapping-based one), and
+  centralises redaction in one helper. A response-payload twin (`response.output_json`) applies the
+  same treatment where a service logs unbounded response bodies.
+- Callers stop hand-assembling keys; a name change happens in one registry, not N call sites; CI
+  catches drift.
+- Consumers must migrate off flat/nested/message-only shapes. Adoption is opt-in per repo and staged,
+  so no consumer breaks on adoption.
+- The registry's `type` / `indexed` metadata lets a schema-enforcing store derive its index mapping
+  from the registry (define once, derive the mapping). That export is store-specific and belongs with
+  the store's own tooling, not in this store-neutral core.
+
+## Load-bearing premises (supersede triggers)
+
+- Powertools `append_keys` stays a shallow merge. If it gained deep-merge semantics, the nested
+  ergonomics argument would reopen.
+- Request-scoped context (bind at entry, clear at exit) is expressible on both backends without a
+  per-request logger factory. If a `contextvars`-based filter cannot isolate concurrent requests
+  cleanly on the long-running (non-Lambda) services, the backend-agnostic claim reopens.
+- The value of a producer-side vocabulary does not depend on the store enforcing a schema. (It is
+  higher, not lower, when the store enforces nothing.) A change of log store does not supersede this
+  ADR.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,26 @@
+# Architecture Decision Records
+
+Decisions that outlive any single change: the "why" behind a choice future readers will want to
+verify, challenge, or build on. These are scoped to this package.
+
+## Format
+
+```markdown
+# ADR-NNN: <Short title>
+
+**Status**: Proposed | Accepted | Superseded by ADR-XXX
+**Date**: YYYY-MM-DD
+
+## Context      # the situation forcing the decision (present tense, the standing rationale)
+## Decision     # what we decide to do
+## Alternatives considered
+## Consequences  # what this makes easier, harder, or rules out
+```
+
+Keep each ADR under two pages. Longer than that means it is a plan, not an ADR.
+
+## Index
+
+| # | Decision | Status | Date |
+|---|----------|--------|------|
+| [001](ADR-001-structured-logging-field-vocabulary.md) | Structured logging field vocabulary (dotted registry + helpers + consistency test) | Proposed | 2026-07-11 |

--- a/docs/guides/powertools-integration.md
+++ b/docs/guides/powertools-integration.md
@@ -106,19 +106,28 @@ logger = get_powertools_logger("my-service", local_dev_colors=False)
 
 ### Structured Logging
 
-The logger supports structured logging with the `extra` parameter:
+The logger supports structured logging with the `extra` parameter. Use the shared
+**[structured logging contract](structured-logging-contract.md)** so field names are
+consistent and queryable across the fleet: dotted, snake_case keys via the `F`
+constants (and consumer-defined domain fields like `order.*`), not ad-hoc flat keys.
 
 ```python
+from nui_shared_utils import F
+
 logger.info(
     "Order processed successfully",
     extra={
-        "order_id": "ORD-12345",
-        "user_id": 789,
-        "total_amount": 250.00,
-        "processing_time_ms": 123
-    }
+        "order.id": "ORD-12345",        # consumer domain field (order.* namespace)
+        F.USER_ID: 789,
+        F.RESPONSE_DURATION_MS: 123,
+    },
 )
 ```
+
+Better still, bind request/user context once per request with the contract's binding
+helpers so every log line carries it automatically. See the
+[contract guide](structured-logging-contract.md) for `bind_request` / `bind_user` /
+`log_exception` and the full field registry.
 
 ### Elasticsearch-Compatible Timestamps
 
@@ -209,7 +218,7 @@ def handler(event, context):
 ### Complete Example (All Features)
 
 ```python
-from nui_shared_utils import get_powertools_logger, powertools_handler
+from nui_shared_utils import get_powertools_logger, powertools_handler, F
 
 logger = get_powertools_logger("order-processor")
 
@@ -230,7 +239,7 @@ def handler(event, context):
     - Proper error response formatting
     """
 
-    logger.info("Processing order", extra={"event_id": event.get("id")})
+    logger.info("Processing order", extra={F.REQUEST_ID: event.get("id")})
 
     try:
         order = validate_order(event)
@@ -239,8 +248,8 @@ def handler(event, context):
         logger.info(
             "Order processed successfully",
             extra={
-                "order_id": order["id"],
-                "processing_time_ms": result["duration"]
+                "order.id": order["id"],                 # consumer domain field
+                F.RESPONSE_DURATION_MS: result["duration"],
             }
         )
 
@@ -250,7 +259,7 @@ def handler(event, context):
         }
 
     except ValidationError as e:
-        logger.error("Order validation failed", extra={"error": str(e)})
+        logger.error("Order validation failed", extra={F.ERROR_TYPE: type(e).__name__, F.ERROR_MESSAGE: str(e)})
         return {
             "statusCode": 400,
             "body": json.dumps({"error": "Invalid order"})
@@ -510,12 +519,17 @@ logger: Union[PowertoolsLogger, PythonLogger] = get_powertools_logger("my-servic
 
 ### 1. Use Structured Logging
 
+Use the [structured logging contract](structured-logging-contract.md)'s dotted field
+names (via `F` and consumer domain fields), not ad-hoc flat keys:
+
 ```python
-# ✓ Good - Searchable, filterable
+from nui_shared_utils import F
+
+# ✓ Good - Searchable, filterable, consistent field names
 logger.info("Order created", extra={
-    "order_id": order.id,
-    "user_id": user.id,
-    "amount": order.total
+    "order.id": order.id,       # consumer domain field
+    F.USER_ID: user.id,
+    F.RESPONSE_STATUS: 200,
 })
 
 # ✗ Bad - Unstructured string
@@ -563,6 +577,8 @@ def handler(event, context):
 ### 4. Graceful Error Handling
 
 ```python
+from nui_shared_utils import F
+
 @powertools_handler(service_name="my-service", slack_alert_channel="#errors")
 @logger.inject_lambda_context
 def handler(event, context):
@@ -573,7 +589,7 @@ def handler(event, context):
 
     except ValidationError as e:
         # Expected errors - log and return 400
-        logger.warning("Validation failed", extra={"error": str(e)})
+        logger.warning("Validation failed", extra={F.ERROR_TYPE: type(e).__name__, F.ERROR_MESSAGE: str(e)})
         return {"statusCode": 400, "body": json.dumps({"error": str(e)})}
 
     # Unexpected errors caught by decorator -> 500 + Slack alert

--- a/docs/guides/structured-logging-contract.md
+++ b/docs/guides/structured-logging-contract.md
@@ -1,0 +1,251 @@
+# Structured Logging Contract
+
+A canonical, dotted, snake_case field vocabulary for structured logs, plus
+backend-agnostic binding helpers that emit it. One contract so logs from
+short-lived Lambda functions and long-running services share the same field shape.
+
+- **What it is**: an importable field registry (`FIELDS` / `F`), request-scoped
+  binders for the two logging backends in use, a payload redactor, and derivations
+  for the redaction set and the field-migration map.
+- **Store-neutral**: it governs how services *emit* fields, not how any log store
+  indexes them. A consistent, typed vocabulary matters under any backend: a
+  schema-enforcing store (Elasticsearch) turns field drift into loud errors; a
+  schema-less store (VictoriaLogs, Loki) accepts drift silently and lets queries
+  and alerts skew. This registry is the producer-side discipline that prevents both.
+- **Why dotted**: dotted keys survive Powertools `append_keys` incremental binding
+  where nested dicts clobber (a producer-side property, independent of the store).
+  See [ADR-001](../decisions/ADR-001-structured-logging-field-vocabulary.md).
+- **Zero heavy deps**: the whole contract is standard-library only. Importing it
+  pulls in no boto3, elasticsearch, slack, or powertools.
+
+## Table of Contents
+
+- [Quick Start](#quick-start)
+- [The Field Registry](#the-field-registry)
+- [Binding Helpers](#binding-helpers)
+- [Request Scope and Context Leakage](#request-scope-and-context-leakage)
+- [Redaction](#redaction)
+- [Extending With Domain Fields](#extending-with-domain-fields)
+- [Deriving the Redaction Set and Migration Map](#deriving-the-redaction-set-and-migration-map)
+- [Choosing a Backend](#choosing-a-backend)
+
+## Quick Start
+
+```python
+import logging
+from nui_shared_utils import F, stdlib_binder, bind_request, bind_user
+
+logger = logging.getLogger("my-service")
+binder = stdlib_binder(logger)  # or powertools_binder(powertools_logger)
+
+def handle(request):
+    with binder.request_scope():                       # context cleared on exit
+        bind_request(binder, method=request.method, path=request.path,
+                     request_id=request.id)
+        bind_user(binder, id=request.user.id, email=request.user.email,
+                  org_id=request.user.org_id)
+
+        # Every log inside the scope carries the bound dotted keys.
+        logger.info("handling request")
+        ...
+        logger.info("response", extra={F.RESPONSE_STATUS: 200,
+                                       F.RESPONSE_DURATION_MS: elapsed_ms})
+```
+
+Emitted (dotted keys, queryable as `request.method`, `user.org_id`, ...):
+
+```json
+{"message": "response", "request.method": "POST", "request.path": "/orders",
+ "request.id": "abc", "user.id": "u1", "user.email": "a@b.com",
+ "user.org_id": "org9", "response.status": 200, "response.duration_ms": 42}
+```
+
+## The Field Registry
+
+Every canonical field is declared once in `nui_shared_utils.logging.fields`. Use the
+`F` constants at call sites so you never hand-type a dotted string:
+
+```python
+from nui_shared_utils import F
+
+logger.info("done", extra={F.RESPONSE_STATUS: 200, F.TARGET: "responses"})
+```
+
+Core namespaces:
+
+| Namespace | Fields | Notes |
+|-----------|--------|-------|
+| `request.*` | `id`, `method`, `path`, `ip`, `body_json` | `body_json` is opaque, retrieval-only (not indexed) |
+| `user.*` | `id`, `email`, `org_id`, `roles` | the principal; `org_id` is the tenant (`company.*` folds in here) |
+| `response.*` | `status`, `duration_ms`, `output_json` | `output_json` is opaque, retrieval-only |
+| `route.*` | `name`, `path` | matched route |
+| `error.*` | `type`, `message`, `stack` | set by `log_exception` |
+| `trace.*` | `id`, `span_id` | Powertools / X-Ray correlation |
+| `git.*` | `commit`, `branch`, `tag` | optional build context, consumer-bound |
+| `target` | (single field) | log index / stream routing |
+
+Each field carries type, indexed flag, sensitivity, and deprecated aliases. `user.email`
+is `pii`; `request.body_json` / `response.output_json` are `redact`. Deprecated names
+map forward, e.g. `request.user` → `user.email`, `api.duration_ms` → `response.duration_ms`.
+
+## Binding Helpers
+
+Helpers take keyword args and emit the right dotted keys. `None` values are dropped,
+so you can pass everything you have and unset fields simply do not appear.
+
+```python
+from nui_shared_utils import (
+    bind_request, bind_user, bind_build_context, log_exception,
+    request_body_fields, response_output_fields,
+)
+
+bind_request(binder, method="POST", path="/orders", ip=client_ip, request_id=rid)
+bind_user(binder, id=u.id, email=u.email, org_id=u.org_id, roles=u.roles)
+bind_build_context(binder, commit=GIT_SHA, branch=GIT_BRANCH)   # optional, at startup
+
+# Exceptions: error.stack is set EXPLICITLY (relying on the backend's own
+# exc_info emits its field name, e.g. Powertools' `stack_trace`, not error.stack).
+try:
+    do_work()
+except Exception as exc:
+    log_exception(binder, exc, "work failed")   # error.type / error.message / error.stack
+
+# Opaque payloads: redacted, then serialised to ONE string field so unbounded
+# caller-controlled keys cannot explode the index field count.
+logger.info("request body", extra=request_body_fields(request.json))
+logger.info("upstream response", extra=response_output_fields(upstream.body))
+```
+
+## Request Scope and Context Leakage
+
+Bound context is **request-scoped**. `binder.request_scope()` sets a `contextvars`
+token on entry and unbinds on exit. This matters on both backends:
+
+- **Long-running services** (ECS): without a scope, a bound `user.id` would persist
+  and bleed into the next, concurrent request. The stdlib binder stores context in a
+  `contextvars.ContextVar`, so concurrent requests (each its own task / thread) are
+  isolated and async-safe.
+- **Warm Lambda invocations**: without a scope, keys bound in one invocation would be
+  inherited by the next on the same warm container. The Powertools binder tracks keys
+  bound inside the scope and calls `remove_keys` on exit.
+
+Wire `request_scope()` into the request-end tween (services) or the handler `finally`
+(Lambda). Always bind inside the scope.
+
+```python
+with binder.request_scope():
+    bind_user(binder, id=u.id)
+    ...
+# here: nothing bound; the next request starts clean
+```
+
+### stdlib binder: child loggers and handler timing
+
+`stdlib_binder(logger)` attaches its context filter to `logger` and to the effective
+handlers up the hierarchy. This covers the common layout where the binder is built on
+an app / root logger that owns the JSON handler, but records are emitted via child
+loggers (`logging.getLogger(__name__)`): a parent logger's *filters* do not run for a
+child's records, but its *handlers* do, so context is injected at the handler.
+
+If you add the JSON handler *after* constructing the binder, or the handler lives on a
+logger other than the one you passed, attach the filter explicitly:
+
+```python
+binder = stdlib_binder(logging.getLogger("my-service"))
+handler = make_json_handler()           # configured later
+logging.getLogger().addHandler(handler)
+binder.install_on(handler)              # or install_on(a_logger)
+```
+
+The filter is a no-op outside a `request_scope` (empty context), so attaching it to a
+shared or root handler is safe.
+
+## Redaction
+
+`request_body_fields` / `response_output_fields` run the payload through
+`default_redactor` before serialising. Two strategies:
+
+- **Deny-list (default)**: masks keys whose name matches a base pattern set
+  (`password`, `token`, `secret`, `authorization`, `api_key`, `cookie`, ...) or a
+  registry-derived sensitive leaf (`email`). Matching is by whole snake_case word, so
+  `X-Api-Key` and `accessToken` are caught but `wildcard` / `author` are not. Good for
+  general debug payloads where most keys are legitimate.
+- **Allow-list (`allow_only=[...]`)**: keeps only the named keys, masks everything
+  else. Use on PII-heavy routes (auth, profile, anything logging headers). The
+  deny-list still applies as a backstop.
+
+```python
+# deny-list default
+request_body_fields(payload)
+# allow-list for a PII-heavy route
+request_body_fields(profile_payload, allow_only=["display_name", "locale"])
+# extend the deny-list for this call
+request_body_fields(payload, deny_extra=["internal_ref"])
+```
+
+Identity fields you *want* logged (email, user id) belong in `bind_user`, which does
+not pass through the redactor. Do not rely on the body redactor to surface identity.
+
+Known v1 gaps (tracked for v2): value-embedded secrets (a token inside a URL string)
+and objects whose `__str__` leaks are not caught, only key *names* are matched.
+
+## Extending With Domain Fields
+
+The shared package stays generic: domain fields (`order.*`, `tender.*`, `auth.*`, ...)
+live in the consumer, not here. Declare them as constants and drift-check them in CI:
+
+```python
+# in your service
+class OrderFields:
+    ORDER_ID = "order.id"
+    ORDER_STATE = "order.state"
+
+logger.info("order processed", extra={OrderFields.ORDER_ID: oid})   # emitted as order.id (order.* namespace)
+```
+
+```python
+# in your service's tests
+from nui_shared_utils import validate_fields
+from myservice.log_fields import OrderFields
+
+def test_order_fields_follow_convention():
+    assert validate_fields(OrderFields) == []   # dotted + snake_case
+```
+
+## Deriving the Redaction Set and Migration Map
+
+The registry is the single source of truth for two otherwise-separate lists:
+
+```python
+from nui_shared_utils import redaction_keys, alias_map
+
+redaction_keys()  # -> frozenset of sensitive leaf names for the deny set
+alias_map()       # -> {"request.user": "user.email", "api.duration_ms": "response.duration_ms", ...}
+```
+
+`redaction_keys()` extends the redactor's deny set with the registry's `pii` / `redact`
+leaves. `alias_map()` drives an old-name → canonical migration or dual-read.
+
+A schema-enforcing store (e.g. Elasticsearch) can also derive its index mapping from
+the registry's `type` / `indexed` metadata (define once, derive the mapping). That
+export is store-specific and lives with the store's own tooling, not in this
+store-neutral core.
+
+## Choosing a Backend
+
+Pick the binder once, at construction (not by duck-typing, which breaks on
+`LoggerAdapter`):
+
+| Backend | Builder | When |
+|---------|---------|------|
+| AWS Powertools `Logger` | `powertools_binder(logger)` | Lambda functions using Powertools |
+| stdlib `logging.Logger` | `stdlib_binder(logger)` | services on the JSON-formatter / `pythonjsonlogger` path |
+
+Both expose the same surface (`bind`, `unbind`, `request_scope`) and the same
+`bind_request` / `bind_user` / ... helpers work against either.
+
+## Related Documentation
+
+- [ADR-001: Structured logging field vocabulary](../decisions/ADR-001-structured-logging-field-vocabulary.md) - the rationale
+- [AWS Powertools Integration](powertools-integration.md) - the logger factory the Powertools binder wraps
+- [Log Processing](log-processing.md) - Kinesis extraction and ES index naming

--- a/nui_shared_utils/__init__.py
+++ b/nui_shared_utils/__init__.py
@@ -120,6 +120,25 @@ _LAZY_EXPORTS = {
     "build_anthropic_client": ("llm", "build_anthropic_client"),
     "call_tool": ("llm", "call_tool"),
     "call_text": ("llm", "call_text"),
+    # Structured logging contract (stdlib-only field registry + binders)
+    "F": ("logging", "F"),
+    "FIELDS": ("logging", "FIELDS"),
+    "Field": ("logging", "Field"),
+    "validate_fields": ("logging", "validate_fields"),
+    "validate_registry": ("logging", "validate_registry"),
+    "redaction_keys": ("logging", "redaction_keys"),
+    "alias_map": ("logging", "alias_map"),
+    "default_redactor": ("logging", "default_redactor"),
+    "powertools_binder": ("logging", "powertools_binder"),
+    "stdlib_binder": ("logging", "stdlib_binder"),
+    "PowertoolsBinder": ("logging", "PowertoolsBinder"),
+    "StdlibBinder": ("logging", "StdlibBinder"),
+    "bind_request": ("logging", "bind_request"),
+    "bind_user": ("logging", "bind_user"),
+    "bind_build_context": ("logging", "bind_build_context"),
+    "log_exception": ("logging", "log_exception"),
+    "request_body_fields": ("logging", "request_body_fields"),
+    "response_output_fields": ("logging", "response_output_fields"),
 }
 
 # Submodules that are optional integrations; ImportError during lazy load
@@ -275,6 +294,26 @@ if TYPE_CHECKING:
         validate_jwt,
     )
     from .llm import build_anthropic_client, call_text, call_tool
+    from .logging import (
+        FIELDS,
+        F,
+        Field,
+        PowertoolsBinder,
+        StdlibBinder,
+        alias_map,
+        bind_build_context,
+        bind_request,
+        bind_user,
+        default_redactor,
+        log_exception,
+        powertools_binder,
+        redaction_keys,
+        request_body_fields,
+        response_output_fields,
+        stdlib_binder,
+        validate_fields,
+        validate_registry,
+    )
     from . import slack_setup
 
 

--- a/nui_shared_utils/logging/__init__.py
+++ b/nui_shared_utils/logging/__init__.py
@@ -1,0 +1,68 @@
+"""Structured logging contract: canonical field registry + backend-agnostic binders.
+
+The fleet's dotted, snake_case logging vocabulary and the helpers that emit it.
+Stdlib-only, so importing this package pulls in no third-party dependency (the
+Powertools binder calls ``append_keys`` / ``remove_keys`` on a logger the caller
+constructs; it never imports ``aws_lambda_powertools`` itself).
+
+Typical use::
+
+    from nui_shared_utils.logging import F, stdlib_binder, bind_request, bind_user
+
+    binder = stdlib_binder(logger)
+    with binder.request_scope():
+        bind_request(binder, method="POST", path="/orders", request_id=rid)
+        bind_user(binder, id=u.id, email=u.email, org_id=u.org_id)
+        logger.info("response", extra={F.RESPONSE_STATUS: 200})
+
+See ``docs/guides/structured-logging-contract.md`` for the full guide and
+``docs/decisions/ADR-001-structured-logging-field-vocabulary.md`` for the rationale.
+"""
+
+from .binding import (
+    PowertoolsBinder,
+    StdlibBinder,
+    bind_build_context,
+    bind_request,
+    bind_user,
+    log_exception,
+    powertools_binder,
+    request_body_fields,
+    response_output_fields,
+    stdlib_binder,
+)
+from .fields import (
+    FIELDS,
+    F,
+    Field,
+    alias_map,
+    redaction_keys,
+    validate_fields,
+    validate_registry,
+)
+from .redaction import MASK, default_redactor
+
+__all__ = [
+    # registry
+    "F",
+    "FIELDS",
+    "Field",
+    "validate_fields",
+    "validate_registry",
+    "redaction_keys",
+    "alias_map",
+    # redaction
+    "default_redactor",
+    "MASK",
+    # binders + helpers
+    "powertools_binder",
+    "stdlib_binder",
+    "PowertoolsBinder",
+    "StdlibBinder",
+    "bind_request",
+    "bind_user",
+    "bind_build_context",
+    "log_exception",
+    "request_body_fields",
+    "response_output_fields",
+]

--- a/nui_shared_utils/logging/binding.py
+++ b/nui_shared_utils/logging/binding.py
@@ -1,0 +1,355 @@
+"""Backend-agnostic, request-scoped binding helpers for structured logging.
+
+Two logging backends are in use across the fleet and this module drives both from
+one call site:
+
+- **Powertools** (:func:`powertools_binder`): persistent context via
+  ``Logger.append_keys`` / ``remove_keys``. Used by short-lived Lambda functions.
+- **stdlib** (:func:`stdlib_binder`): a ``contextvars``-backed ``logging.Filter``
+  that injects bound fields onto each record. Used by long-running services on the
+  ``pythonjsonlogger`` path, which has no native persistent context.
+
+Both binders are **request-scoped**: :meth:`request_scope` sets a ``contextvars``
+token on entry and unbinds on exit, so bound context cannot leak across concurrent
+requests on a long-running service or across warm Lambda invocations. ``contextvars``
+(not thread-locals) so isolation holds under ``asyncio`` too. Wire ``request_scope``
+into the request-end tween / handler ``finally``.
+
+The backend is chosen **once at construction**, not by ``hasattr`` duck-typing
+(which breaks on ``LoggerAdapter`` and other wrappers).
+
+    binder = powertools_binder(logger)   # or stdlib_binder(logger)
+    with binder.request_scope():
+        bind_request(binder, method="POST", path=p, request_id=rid)
+        bind_user(binder, id=u.id, email=u.email, org_id=u.org_id)
+        logger.info("response", extra={F.RESPONSE_STATUS: 200})   # carries bound keys
+    # on exit: bound keys removed, no cross-request / cross-invocation leakage
+
+Values are always emitted as dotted keys (``request.method``), never nested dicts.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import json
+import logging
+import traceback
+from contextlib import contextmanager
+from typing import Any, Dict, Iterable, Iterator, Mapping, Optional
+
+from .fields import F
+from .redaction import default_redactor
+
+# Monotonic counter so each binder gets a distinct ContextVar name (ContextVar
+# names are for debugging only, but distinct names avoid confusion in tracebacks).
+_binder_seq = 0
+
+
+def _next_seq() -> int:
+    global _binder_seq
+    _binder_seq += 1
+    return _binder_seq
+
+
+def _drop_none(mapping: Mapping[str, Any]) -> Dict[str, Any]:
+    """Return ``mapping`` without keys whose value is ``None``."""
+    return {k: v for k, v in mapping.items() if v is not None}
+
+
+class PowertoolsBinder:
+    """Request-scoped binder over an AWS Powertools ``Logger``.
+
+    Binding calls ``logger.append_keys``; :meth:`request_scope` tracks the keys
+    bound within the scope and calls ``logger.remove_keys`` on exit so a warm
+    invocation does not inherit the previous request's context.
+    """
+
+    def __init__(self, logger: Any):
+        self.logger = logger
+        self._scope_keys: contextvars.ContextVar[Optional[set]] = contextvars.ContextVar(
+            f"nui_log_pt_scope_{_next_seq()}", default=None
+        )
+
+    def bind(self, mapping: Mapping[str, Any]) -> None:
+        """Append the given dotted keys to the logger context (``None`` dropped)."""
+        clean = _drop_none(mapping)
+        if not clean:
+            return
+        self.logger.append_keys(**clean)
+        tracked = self._scope_keys.get()
+        if tracked is not None:
+            tracked.update(clean.keys())
+
+    def unbind(self, keys: Iterable[str]) -> None:
+        """Remove the given keys from the logger context."""
+        keys = list(keys)
+        if keys:
+            self.logger.remove_keys(keys)
+
+    @contextmanager
+    def request_scope(self) -> Iterator["PowertoolsBinder"]:
+        """Scope bound keys to the block and restore prior state on exit.
+
+        Keys bound inside the block are removed on exit, but a key that already held
+        a process-level value before the scope (e.g. build context bound at startup
+        and then rebound in-request) is restored to that prior value rather than
+        removed. Restoration uses the logger's ``get_current_keys`` when available;
+        without it, scoped keys are simply removed.
+        """
+        get_keys = getattr(self.logger, "get_current_keys", None)
+        prior = dict(get_keys()) if callable(get_keys) else None
+        token = self._scope_keys.set(set())
+        try:
+            yield self
+        finally:
+            scoped = self._scope_keys.get() or set()
+            if scoped:
+                if prior is not None:
+                    added = [k for k in scoped if k not in prior]
+                    restore = {k: prior[k] for k in scoped if k in prior}
+                    if added:
+                        self.logger.remove_keys(added)
+                    if restore:
+                        self.logger.append_keys(**restore)
+                else:
+                    self.logger.remove_keys(list(scoped))
+            self._scope_keys.reset(token)
+
+
+class _ContextVarLogFilter(logging.Filter):
+    """A ``logging.Filter`` that injects the current bound fields onto each record.
+
+    Reads the binder's ``contextvars`` value at emit time, so concurrent requests
+    (each in its own task / thread context) see only their own bound fields. An
+    explicit per-call ``extra=`` value already on the record wins (bound context
+    never clobbers it).
+    """
+
+    def __init__(self, ctx: "contextvars.ContextVar[Optional[Dict[str, Any]]]"):
+        super().__init__()
+        self._ctx = ctx
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        fields = self._ctx.get()
+        if fields:
+            for key, value in fields.items():
+                if not hasattr(record, key):
+                    setattr(record, key, value)
+        return True
+
+
+class StdlibBinder:
+    """Request-scoped binder over a standard-library ``logging.Logger``.
+
+    Bound fields live in a ``contextvars.ContextVar`` and are injected onto every
+    record by a filter installed on the logger. :meth:`request_scope` snapshots the
+    context on entry and resets it on exit, so a long-running service does not bleed
+    one request's context into another (async-safe under ``contextvars``).
+    """
+
+    def __init__(self, logger: logging.Logger):
+        self.logger = logger
+        self._ctx: contextvars.ContextVar[Optional[Dict[str, Any]]] = contextvars.ContextVar(
+            f"nui_log_std_ctx_{_next_seq()}", default=None
+        )
+        self._filter = _ContextVarLogFilter(self._ctx)
+        self.install_on(logger)
+
+    def install_on(self, target: Any) -> None:
+        """Attach the context filter to a ``Logger`` or ``Handler`` (idempotent).
+
+        A logger's *filters* run only for records emitted via that exact logger, not
+        for records propagated up from child loggers (``getLogger("svc.module")``).
+        A *handler's* filters, by contrast, run for every record that reaches the
+        handler, including propagated ones. So the filter is installed on the
+        logger (direct emits) and on the effective handlers up the hierarchy (child
+        emits). The filter is a no-op outside a ``request_scope`` (empty context),
+        so attaching it to a shared / root handler is safe.
+
+        Call this explicitly for handlers configured *after* the binder is built, or
+        when your JSON handler lives on a logger other than the one passed here.
+        """
+        if isinstance(target, logging.Handler):
+            if self._filter not in target.filters:
+                target.addFilter(self._filter)
+            return
+        if self._filter not in target.filters:
+            target.addFilter(self._filter)
+        node: Optional[logging.Logger] = target
+        while node is not None:
+            for handler in node.handlers:
+                if self._filter not in handler.filters:
+                    handler.addFilter(self._filter)
+            if not node.propagate:
+                break
+            node = node.parent
+
+    def bind(self, mapping: Mapping[str, Any]) -> None:
+        """Merge the given dotted keys into the current context (``None`` dropped)."""
+        clean = _drop_none(mapping)
+        if not clean:
+            return
+        current = self._ctx.get()
+        merged = dict(current) if current else {}
+        merged.update(clean)
+        self._ctx.set(merged)
+
+    def unbind(self, keys: Iterable[str]) -> None:
+        """Remove the given keys from the current context."""
+        current = self._ctx.get()
+        if not current:
+            return
+        drop = set(keys)
+        self._ctx.set({k: v for k, v in current.items() if k not in drop})
+
+    def current_fields(self) -> Dict[str, Any]:
+        """Return a snapshot of the currently-bound fields (introspection / tests)."""
+        current = self._ctx.get()
+        return dict(current) if current else {}
+
+    @contextmanager
+    def request_scope(self) -> Iterator["StdlibBinder"]:
+        """Isolate binds made inside the block; restore prior context on exit."""
+        current = self._ctx.get()
+        token = self._ctx.set(dict(current) if current else {})
+        try:
+            yield self
+        finally:
+            self._ctx.reset(token)
+
+
+def powertools_binder(logger: Any) -> PowertoolsBinder:
+    """Build a request-scoped binder over an AWS Powertools ``Logger``."""
+    return PowertoolsBinder(logger)
+
+
+def stdlib_binder(logger: logging.Logger) -> StdlibBinder:
+    """Build a request-scoped binder over a standard-library ``logging.Logger``."""
+    return StdlibBinder(logger)
+
+
+# --- Field-specific binding helpers (callers never hand-type a dotted string) ---
+
+
+def bind_request(
+    binder: Any,
+    *,
+    method: Optional[str] = None,
+    path: Optional[str] = None,
+    ip: Optional[str] = None,
+    request_id: Optional[str] = None,
+) -> None:
+    """Bind request context (``request.method`` / ``.path`` / ``.ip`` / ``.id``)."""
+    binder.bind(
+        {
+            F.REQUEST_METHOD: method,
+            F.REQUEST_PATH: path,
+            F.REQUEST_IP: ip,
+            F.REQUEST_ID: request_id,
+        }
+    )
+
+
+def bind_user(
+    binder: Any,
+    *,
+    id: Optional[str] = None,
+    email: Optional[str] = None,
+    org_id: Optional[str] = None,
+    roles: Optional[Any] = None,
+) -> None:
+    """Bind principal identity (``user.id`` / ``.email`` / ``.org_id`` / ``.roles``)."""
+    binder.bind(
+        {
+            F.USER_ID: id,
+            F.USER_EMAIL: email,
+            F.USER_ORG_ID: org_id,
+            F.USER_ROLES: roles,
+        }
+    )
+
+
+def bind_build_context(
+    binder: Any,
+    *,
+    commit: Optional[str] = None,
+    branch: Optional[str] = None,
+    tag: Optional[str] = None,
+) -> None:
+    """Bind optional build metadata (``git.commit`` / ``.branch`` / ``.tag``).
+
+    Not bound automatically; the consumer decides whether build metadata is
+    available at runtime and calls this once at startup / per request.
+    """
+    binder.bind(
+        {
+            F.GIT_COMMIT: commit,
+            F.GIT_BRANCH: branch,
+            F.GIT_TAG: tag,
+        }
+    )
+
+
+def log_exception(binder: Any, exc: BaseException, message: str) -> None:
+    """Log ``exc`` at ERROR with explicit ``error.*`` fields.
+
+    ``error.stack`` is set explicitly from the traceback so the canonical field
+    always carries the trace. This uses ``logger.error`` (not ``logger.exception``)
+    deliberately: ``logger.exception`` sets ``exc_info=True``, which makes the
+    backend emit its *own* traceback field (Powertools' ``stack_trace``, stdlib's
+    ``exc_text``) on top of ``error.stack`` when called inside an ``except`` block,
+    i.e. the same trace twice under two names. With ``logger.error``, ``error.stack``
+    is the single source.
+    """
+    binder.logger.error(
+        message,
+        extra={
+            F.ERROR_TYPE: type(exc).__name__,
+            F.ERROR_MESSAGE: str(exc),
+            # 3-arg form for Python 3.9 compatibility (single-arg added in 3.10).
+            F.ERROR_STACK: "".join(traceback.format_exception(type(exc), exc, exc.__traceback__)),
+        },
+    )
+
+
+def _redact_kwargs(allow_only: Optional[Iterable[str]], deny_extra: Optional[Iterable[str]]) -> Dict[str, Any]:
+    # ``deny_extra`` is only forwarded when set, so a custom ``redactor`` that does
+    # not accept it still works when the caller does not use it.
+    kwargs: Dict[str, Any] = {"allow_only": allow_only}
+    if deny_extra is not None:
+        kwargs["deny_extra"] = deny_extra
+    return kwargs
+
+
+def request_body_fields(
+    payload: Any,
+    *,
+    allow_only: Optional[Iterable[str]] = None,
+    deny_extra: Optional[Iterable[str]] = None,
+    redactor: Any = default_redactor,
+) -> Dict[str, str]:
+    """Redact and serialise a request body into a single ``request.body_json`` field.
+
+    Returns a mapping ready to splat into ``extra=`` (or pass to ``binder.bind``).
+    The body is redacted (deny-list by default, allow-list via ``allow_only``,
+    extended for this call via ``deny_extra``) then JSON-serialised with
+    ``default=str`` so non-serialisable values do not raise.
+    """
+    redacted = redactor(payload, **_redact_kwargs(allow_only, deny_extra))
+    return {F.REQUEST_BODY_JSON: json.dumps(redacted, default=str)}
+
+
+def response_output_fields(
+    payload: Any,
+    *,
+    allow_only: Optional[Iterable[str]] = None,
+    deny_extra: Optional[Iterable[str]] = None,
+    redactor: Any = default_redactor,
+) -> Dict[str, str]:
+    """Redact and serialise a response payload into a single ``response.output_json`` field.
+
+    The response twin of :func:`request_body_fields`, for services that log
+    unbounded response bodies.
+    """
+    redacted = redactor(payload, **_redact_kwargs(allow_only, deny_extra))
+    return {F.RESPONSE_OUTPUT_JSON: json.dumps(redacted, default=str)}

--- a/nui_shared_utils/logging/fields.py
+++ b/nui_shared_utils/logging/fields.py
@@ -1,0 +1,253 @@
+"""Canonical structured-logging field registry (the fleet's logging contract).
+
+This module is the single source of truth for the dotted, snake_case field names
+that structured logs use. It is deliberately **stdlib-only** so it stays cheap to
+import and light in a Lambda bundle: no elasticsearch, powertools, or third-party
+dependency is touched here.
+
+Two layers:
+
+- A **generic core** registry (:data:`FIELDS`) of namespaces every web / event
+  service has: ``request.*``, ``user.*``, ``route.*``, ``response.*``,
+  ``error.*``, ``trace.*``, ``git.*``, plus the ``target`` routing field and the
+  opaque ``request.body_json`` / ``response.output_json`` retrieval fields.
+- An **extension pattern**: domain fields (``order.*``, ``tender.*``, ``api.*``,
+  ``auth.*``, ...) are defined by each consumer in its own constants module and
+  drift-checked with :func:`validate_fields`, so the shared package stays generic.
+
+Each :class:`Field` carries a type, an indexed flag, a sensitivity, an owner, and
+any deprecated aliases. That one structure is the derive-once source for two lists
+that were otherwise hand-maintained:
+
+- :func:`redaction_keys` -- the default redaction deny set (from ``sensitivity``).
+- :func:`alias_map` -- the old-name -> canonical-name migration map (from ``aliases``).
+
+The contract is **store-neutral**: it governs how services *emit* fields, not how
+any log store indexes them. Its value is a consistent, typed field vocabulary
+across the fleet, which matters under any backend. Schema-enforcing stores turn
+field drift into loud errors; schema-less stores accept the drift silently and let
+queries and alerts skew. A producer-side registry prevents both.
+
+Wire shape is **dotted** (``request.method``), not nested dicts: dotted keys
+survive Powertools ``append_keys`` incremental binding where nested dicts clobber
+(a producer-side property, independent of the store). See
+``docs/decisions/ADR-001-structured-logging-field-vocabulary.md``.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field as _dc_field
+from typing import Dict, List, Tuple
+
+# Leaf datatypes a field may declare. These document producer intent (what a field
+# is meant to hold) and give a schema-enforcing store a type to map to; a schema-less
+# store coerces at query time, so the declared type is what keeps emitters honest.
+_KNOWN_TYPES = frozenset({"keyword", "text", "long", "boolean", "date", "geo_point"})
+# Sensitivity levels that drive default redaction.
+_SENSITIVITIES = frozenset({"none", "pii", "redact"})
+# A single dotted segment: lowercase snake_case, must start with a letter.
+_SEGMENT_RE = re.compile(r"^[a-z][a-z0-9_]*$")
+
+
+@dataclass(frozen=True)
+class Field:
+    """One canonical log field.
+
+    Attributes:
+        key: Dotted, snake_case field name (e.g. ``"request.method"``).
+        type: Leaf datatype the field is meant to hold (``keyword`` / ``text`` /
+            ``long`` / ``boolean`` / ``date`` / ``geo_point``). Producer intent that
+            keeps emitters consistent; not enforced by this module.
+        indexed: ``False`` marks a retrieval-only field: stored for lookup but not
+            meant to be queried or faceted (opaque, unbounded payloads like
+            ``request.body_json``).
+        sensitivity: ``none`` | ``pii`` | ``redact``. ``pii`` / ``redact`` fields
+            contribute their leaf name to the default redaction deny set.
+        owner: Namespace owner; ``core`` for shared fields.
+        aliases: Deprecated dotted names that map to this field, used to build the
+            migration / dual-read map.
+    """
+
+    key: str
+    type: str
+    indexed: bool = True
+    sensitivity: str = "none"
+    owner: str = "core"
+    aliases: Tuple[str, ...] = _dc_field(default=())
+
+
+class F:
+    """Field-name constants for ergonomic call sites (``F.REQUEST_METHOD``).
+
+    Every constant here has a matching entry in :data:`FIELDS`; the invariant is
+    asserted by :func:`validate_registry` at import time.
+    """
+
+    # request.*
+    REQUEST_ID = "request.id"
+    REQUEST_METHOD = "request.method"
+    REQUEST_PATH = "request.path"
+    REQUEST_IP = "request.ip"
+    REQUEST_BODY_JSON = "request.body_json"
+    # user.*
+    USER_ID = "user.id"
+    USER_EMAIL = "user.email"
+    USER_ORG_ID = "user.org_id"
+    USER_ROLES = "user.roles"
+    # response.*
+    RESPONSE_STATUS = "response.status"
+    RESPONSE_DURATION_MS = "response.duration_ms"
+    RESPONSE_OUTPUT_JSON = "response.output_json"
+    # route.*
+    ROUTE_NAME = "route.name"
+    ROUTE_PATH = "route.path"
+    # error.*
+    ERROR_TYPE = "error.type"
+    ERROR_MESSAGE = "error.message"
+    ERROR_STACK = "error.stack"
+    # trace.*
+    TRACE_ID = "trace.id"
+    TRACE_SPAN_ID = "trace.span_id"
+    # routing + build context
+    TARGET = "target"
+    GIT_COMMIT = "git.commit"
+    GIT_BRANCH = "git.branch"
+    GIT_TAG = "git.tag"
+
+
+# The canonical registry. Keyed by dotted name; the key must equal ``Field.key``.
+FIELDS: Dict[str, Field] = {
+    "request.id": Field("request.id", "keyword"),
+    "request.method": Field("request.method", "keyword"),
+    "request.path": Field("request.path", "keyword", aliases=("request.url",)),
+    "request.ip": Field("request.ip", "keyword"),
+    # Opaque, retrieval-only: unbounded caller-controlled body, redacted then
+    # serialised to one string so it cannot explode the index field count.
+    "request.body_json": Field("request.body_json", "keyword", indexed=False, sensitivity="redact"),
+    "user.id": Field("user.id", "keyword"),
+    "user.email": Field("user.email", "keyword", sensitivity="pii", aliases=("request.user",)),
+    # Tenant. company.* folds in here (a distinct company name, if ever needed,
+    # is a consumer domain field).
+    "user.org_id": Field("user.org_id", "keyword", aliases=("request.company", "request.company_id")),
+    "user.roles": Field("user.roles", "keyword"),  # array; ES arrays are implicit
+    "response.status": Field("response.status", "long"),
+    "response.duration_ms": Field(
+        "response.duration_ms",
+        "long",
+        aliases=("response.duration", "api.duration_ms", "duration.ms"),
+    ),
+    # The response twin of request.body_json (unbounded response payloads).
+    "response.output_json": Field("response.output_json", "keyword", indexed=False, sensitivity="redact"),
+    "route.name": Field("route.name", "keyword"),
+    "route.path": Field("route.path", "keyword"),
+    "error.type": Field("error.type", "keyword"),
+    "error.message": Field("error.message", "text"),
+    "error.stack": Field("error.stack", "text"),
+    "trace.id": Field("trace.id", "keyword", aliases=("request.trace_id",)),
+    "trace.span_id": Field("trace.span_id", "keyword"),
+    # ES index routing. Constrain to known values at the consumer (misroute risk).
+    "target": Field("target", "keyword"),
+    # Optional build context; consumer-bound via bind_build_context, not automatic.
+    "git.commit": Field("git.commit", "keyword"),
+    "git.branch": Field("git.branch", "keyword"),
+    "git.tag": Field("git.tag", "keyword"),
+}
+
+
+def _key_errors(key: object) -> List[str]:
+    """Return a list of naming problems for ``key`` (empty means valid).
+
+    A valid key is one or more ``.``-joined snake_case segments, each starting
+    with a lowercase letter: ``target``, ``request.method``, ``user.org_id``.
+    Rejects camelCase, hyphens, leading digits, and empty segments.
+    """
+    if not isinstance(key, str) or not key:
+        return [f"{key!r}: not a non-empty string"]
+    errors: List[str] = []
+    for seg in key.split("."):
+        if not _SEGMENT_RE.match(seg):
+            errors.append(f"{key!r}: segment {seg!r} is not lowercase snake_case")
+    return errors
+
+
+def validate_registry() -> List[str]:
+    """Validate the core :data:`FIELDS` registry, returning a list of errors.
+
+    Checks that every key matches its ``Field.key``, is dotted snake_case, has a
+    known type and sensitivity, and that aliases are globally unique and do not
+    collide with any canonical key. Also asserts every :class:`F` constant is a
+    registered field. An empty list means the registry is internally consistent.
+    """
+    errors: List[str] = []
+    seen_aliases: Dict[str, str] = {}
+    for key, fld in FIELDS.items():
+        if fld.key != key:
+            errors.append(f"{key!r}: Field.key {fld.key!r} does not match registry key")
+        errors.extend(_key_errors(key))
+        if fld.type not in _KNOWN_TYPES:
+            errors.append(f"{key!r}: unknown type {fld.type!r}")
+        if fld.sensitivity not in _SENSITIVITIES:
+            errors.append(f"{key!r}: unknown sensitivity {fld.sensitivity!r}")
+        for alias in fld.aliases:
+            errors.extend(_key_errors(alias))
+            if alias in FIELDS:
+                errors.append(f"{key!r}: alias {alias!r} collides with a canonical field key")
+            if alias in seen_aliases:
+                errors.append(f"alias {alias!r} used by both {seen_aliases[alias]!r} and {key!r}")
+            else:
+                seen_aliases[alias] = key
+    # Every F constant must be a real field.
+    for name in dir(F):
+        if name.startswith("_"):
+            continue
+        value = getattr(F, name)
+        if isinstance(value, str) and value not in FIELDS:
+            errors.append(f"F.{name} = {value!r} is not in FIELDS")
+    return errors
+
+
+def validate_fields(*modules: object) -> List[str]:
+    """Validate that a consumer's field constants are dotted snake_case names.
+
+    Pass one or more classes / modules whose public (non-underscore) string
+    attributes are log field names. Returns a list of naming errors (empty means
+    all valid), so a consumer's CI can assert ``validate_fields(OrderFields) == []``
+    and catch drift from the shared convention.
+    """
+    errors: List[str] = []
+    for mod in modules:
+        label = getattr(mod, "__name__", type(mod).__name__)
+        for name in dir(mod):
+            if name.startswith("_"):
+                continue
+            value = getattr(mod, name)
+            if not isinstance(value, str):
+                continue
+            errors.extend(f"{label}.{name}: {err}" for err in _key_errors(value))
+    return errors
+
+
+def redaction_keys() -> frozenset:
+    """Return the leaf names of ``pii`` / ``redact`` fields for the deny set.
+
+    These extend the redactor's base pattern list so that any payload key with a
+    sensitive name (e.g. ``email`` from ``user.email``) is masked by default.
+    """
+    return frozenset(fld.key.split(".")[-1] for fld in FIELDS.values() if fld.sensitivity in ("pii", "redact"))
+
+
+def alias_map() -> Dict[str, str]:
+    """Return the ``old_name -> canonical_key`` migration map from all aliases."""
+    mapping: Dict[str, str] = {}
+    for fld in FIELDS.values():
+        for alias in fld.aliases:
+            mapping[alias] = fld.key
+    return mapping
+
+
+# Guard the registry at import: a malformed core registry is a bug that should
+# surface the moment the logging package is first used, not silently at query time.
+_REGISTRY_ERRORS = validate_registry()
+if _REGISTRY_ERRORS:
+    raise ValueError("Invalid logging field registry:\n  " + "\n  ".join(_REGISTRY_ERRORS))

--- a/nui_shared_utils/logging/redaction.py
+++ b/nui_shared_utils/logging/redaction.py
@@ -1,0 +1,189 @@
+"""Recursive redaction for opaque log payloads (deny-list default, allow-list opt-in).
+
+Bodies and response payloads carry unbounded, caller-controlled keys, so they are
+scrubbed before being serialised into ``request.body_json`` / ``response.output_json``.
+Two strategies, layered:
+
+- **Deny-list (default)**: a base set of sensitive key-name patterns (password,
+  token, secret, authorization, api_key, cookie, ...) plus the ``pii`` / ``redact``
+  leaf names from the field registry, matched recursively and masked. Suitable for
+  general debug payloads where most keys are legitimate and only known-sensitive
+  ones must go.
+- **Allow-list (opt-in via ``allow_only``)**: only the named keys survive, every
+  other key is masked. PII-heavy surfaces (auth, profile, anything logging headers
+  or authorization) should pass ``allow_only`` so the payload is a known safe
+  subset rather than "everything minus the deny-list".
+
+The redactor never mutates the caller's structure: it rebuilds the dict / list
+spine and shares only leaf scalars (which are treated as immutable and are
+serialised with ``json.dumps(default=str)`` downstream).
+
+Documented v1 gaps (not silently accepted, tracked for v2):
+
+- **Value-embedded secrets**: a bearer token or JWT inside a URL string, or a
+  secret in a free-text value, is not caught (only key *names* are matched).
+- **Leaky custom objects**: an object whose ``__str__`` / ``__repr__`` exposes a
+  secret is serialised as-is.
+
+Value-pattern masking (matching secret-shaped *values*, not just key names) is v2.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any, Dict, Iterable, Optional
+
+from .fields import redaction_keys
+
+#: Mask substituted for redacted values.
+MASK = "***REDACTED***"
+
+#: Base deny-list of sensitive key-name patterns. Deny matching is by whole
+#: snake_case *word* (or phrase), so header variants like ``X-Api-Key`` and
+#: camelCase like ``accessToken`` match, while ``mapping`` / ``author`` /
+#: ``wildcard`` do NOT falsely match ``pin`` / ``auth`` / ``card``. Extend per
+#: call via ``deny_extra`` rather than editing this set.
+_BASE_DENY = frozenset(
+    {
+        "password",
+        "passwd",
+        "pwd",
+        "secret",
+        "token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "authorization",
+        "auth",
+        "jwt",
+        "bearer",
+        "api_key",
+        "apikey",
+        "access_key",
+        "secret_key",
+        "private_key",
+        "session_id",
+        "cookie",
+        "set_cookie",
+        "headers",
+        "credentials",
+        "card_number",
+        "cvv",
+        "cvc",
+        "ssn",
+    }
+)
+
+#: High-signal secret tokens also matched as a plain substring of the
+#: separator-stripped key, so all-lowercase concatenations without a delimiter
+#: (``accesstoken``, ``apitoken``, ``privatekey``) are caught too. Kept to long,
+#: unambiguous words to avoid masking innocent keys (``key`` is deliberately NOT
+#: here: it would mask ``monkey`` / ``primary_key``).
+_SUBSTRING_DENY = frozenset(
+    {
+        "password",
+        "passwd",
+        "secret",
+        "token",
+        "authorization",
+        "apikey",
+        "credential",
+        "privatekey",
+        "accesskey",
+        "secretkey",
+    }
+)
+
+_NON_ALNUM = re.compile(r"[^a-z0-9]")
+_CAMEL_1 = re.compile(r"(?<=[a-z0-9])(?=[A-Z])")
+_CAMEL_2 = re.compile(r"(?<=[A-Z])(?=[A-Z][a-z])")
+_SEP = re.compile(r"[-.\s]+")
+_MULTI_US = re.compile(r"_+")
+
+
+def _to_snake(name: object) -> str:
+    """Normalise a key to lowercase snake_case (camelCase and ``-`` / ``.`` unified).
+
+    ``apiKey`` / ``X-Api-Key`` / ``api.key`` all normalise to ``api_key``, so the
+    matcher is agnostic to the caller's naming style.
+    """
+    text = str(name)
+    text = _CAMEL_1.sub("_", text)
+    text = _CAMEL_2.sub("_", text)
+    text = _SEP.sub("_", text.lower())
+    return _MULTI_US.sub("_", text).strip("_")
+
+
+def _in_deny(snake_key: str, deny: frozenset) -> bool:
+    """True if ``snake_key`` matches a deny phrase.
+
+    Two layers:
+
+    - Whole-word / phrase match on ``_``-delimited words (avoids short-token false
+      positives: ``card`` matches ``card_number`` and ``card`` but not ``wildcard``).
+    - Plain substring match for the curated high-signal tokens in
+      :data:`_SUBSTRING_DENY`, over the separator-stripped key, so all-lowercase
+      concatenations (``accesstoken``, ``apitoken``) are caught too.
+    """
+    for phrase in deny:
+        if (
+            snake_key == phrase
+            or snake_key.startswith(phrase + "_")
+            or snake_key.endswith("_" + phrase)
+            or ("_" + phrase + "_") in snake_key
+        ):
+            return True
+    collapsed = _NON_ALNUM.sub("", snake_key)
+    return any(token in collapsed for token in _SUBSTRING_DENY)
+
+
+def _build_deny(deny_extra: Optional[Iterable[str]]) -> frozenset:
+    keys = set(_BASE_DENY) | set(redaction_keys())
+    if deny_extra:
+        keys |= set(deny_extra)
+    return frozenset(_to_snake(k) for k in keys)
+
+
+def _redact(value: object, deny: frozenset, allow: Optional[frozenset]) -> object:
+    if isinstance(value, dict):
+        out: Dict[Any, Any] = {}
+        for key, val in value.items():
+            snake_key = _to_snake(key)
+            if _in_deny(snake_key, deny):
+                out[key] = MASK
+            elif allow is not None and snake_key not in allow:
+                out[key] = MASK
+            else:
+                out[key] = _redact(val, deny, allow)
+        return out
+    if isinstance(value, (list, tuple)):
+        return [_redact(item, deny, allow) for item in value]
+    return value
+
+
+def default_redactor(
+    payload: object,
+    *,
+    allow_only: Optional[Iterable[str]] = None,
+    deny_extra: Optional[Iterable[str]] = None,
+) -> object:
+    """Return a redacted copy of ``payload`` without mutating the original.
+
+    Descends dicts and lists. In the default deny-list mode, keys whose name
+    matches the base pattern set or a registry-derived sensitive leaf (by whole
+    snake_case word) are masked. Passing ``allow_only`` switches to allow-list
+    mode: only keys whose normalised name exactly equals a named key survive at any
+    depth. The deny-list still applies as a backstop, so a key that is both allowed
+    and sensitive is still masked (identity fields belong in ``bind_user``, not in a
+    redacted body). Non-container payloads (str, int, ``None``, ...) pass through
+    unchanged.
+
+    Args:
+        payload: The structure to redact (typically a request / response body).
+        allow_only: If given, keep only these key names (exact, normalised); mask
+            the rest. Use on PII-heavy routes.
+        deny_extra: Extra sensitive key names to add to the deny-list for this call.
+    """
+    deny = _build_deny(deny_extra)
+    allow = frozenset(_to_snake(k) for k in allow_only) if allow_only is not None else None
+    return _redact(payload, deny, allow)

--- a/tests/test_lazy_imports.py
+++ b/tests/test_lazy_imports.py
@@ -53,6 +53,35 @@ def test_bare_package_import_does_not_load_anthropic():
     assert "llm=False" in output
 
 
+def test_logging_contract_import_stays_dependency_free():
+    """``from nui_shared_utils.logging import ...`` must pull in no heavy deps.
+
+    The logging contract (field registry + binders) is stdlib-only by design so it
+    is cheap to import and light in a Lambda bundle. It must not transitively load
+    boto3, aws-lambda-powertools, elasticsearch, or slack_sdk.
+    """
+    output = _run("""
+        import sys
+        from nui_shared_utils.logging import F, stdlib_binder, bind_request  # noqa: F401
+        for mod in ("boto3", "aws_lambda_powertools", "elasticsearch", "slack_sdk"):
+            print(f"{mod}={mod in sys.modules}")
+        """)
+    assert "boto3=False" in output
+    assert "aws_lambda_powertools=False" in output
+    assert "elasticsearch=False" in output
+    assert "slack_sdk=False" in output
+
+
+def test_bare_package_import_does_not_load_logging_submodule():
+    """``import nui_shared_utils`` must not eagerly import the logging subpackage."""
+    output = _run("""
+        import sys
+        import nui_shared_utils  # noqa: F401
+        print(f"logging={'nui_shared_utils.logging' in sys.modules}")
+        """)
+    assert "logging=False" in output
+
+
 def test_jwt_auth_import_does_not_load_boto3():
     """``from nui_shared_utils.jwt_auth import check_auth`` must stay lazy.
 

--- a/tests/test_logging_binding.py
+++ b/tests/test_logging_binding.py
@@ -1,0 +1,369 @@
+"""Tests for the backend-agnostic, request-scoped binding helpers.
+
+Covers the two load-bearing lifecycle properties from the design:
+
+- **Powertools**: two dotted ``append_keys`` binds both survive, and a warm
+  invocation does not inherit the previous request's context (``request_scope``
+  unbinds on exit).
+- **stdlib**: concurrent requests do not bleed context into each other
+  (``contextvars``-backed, async-safe).
+"""
+
+import asyncio
+import logging
+
+import pytest
+
+from nui_shared_utils.logging import (
+    F,
+    bind_build_context,
+    bind_request,
+    bind_user,
+    log_exception,
+    powertools_binder,
+    request_body_fields,
+    response_output_fields,
+    stdlib_binder,
+)
+
+pytestmark = pytest.mark.unit
+
+
+class FakePowertoolsLogger:
+    """Minimal stand-in for a Powertools ``Logger``.
+
+    Models the persistent-context semantics the binder depends on: ``append_keys``
+    accumulates into a shared dict (shallow, top-level), ``remove_keys`` deletes,
+    and ``info`` / ``exception`` snapshot ``context + extra`` for assertions. Using
+    a fake keeps the test independent of aws-lambda-powertools being installed.
+    """
+
+    def __init__(self):
+        self.context = {}
+        self.records = []
+
+    def append_keys(self, **keys):
+        self.context.update(keys)
+
+    def remove_keys(self, keys):
+        for key in keys:
+            self.context.pop(key, None)
+
+    def get_current_keys(self):
+        return dict(self.context)
+
+    def _emit(self, level, message, extra=None):
+        merged = dict(self.context)
+        if extra:
+            merged.update(extra)
+        self.records.append({"level": level, "message": message, "fields": merged})
+
+    def info(self, message, extra=None):
+        self._emit("INFO", message, extra)
+
+    def error(self, message, extra=None):
+        self._emit("ERROR", message, extra)
+
+    def exception(self, message, extra=None):
+        self._emit("EXCEPTION", message, extra)
+
+
+def _capturing_stdlib_logger(name):
+    """A stdlib logger whose emitted records are captured for inspection."""
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    logger.handlers = []
+    captured = []
+
+    class _Cap(logging.Handler):
+        def emit(self, record):
+            captured.append(record)
+
+    logger.addHandler(_Cap())
+    return logger, captured
+
+
+class TestPowertoolsBinder:
+    def test_two_dotted_binds_both_survive(self):
+        logger = FakePowertoolsLogger()
+        binder = powertools_binder(logger)
+        binder.bind({"request.a": 1})
+        binder.bind({"request.b": 2})
+        logger.info("msg")
+        fields = logger.records[-1]["fields"]
+        assert fields["request.a"] == 1
+        assert fields["request.b"] == 2
+
+    def test_request_scope_unbinds_on_exit(self):
+        logger = FakePowertoolsLogger()
+        binder = powertools_binder(logger)
+        with binder.request_scope():
+            bind_request(binder, method="POST", path="/orders", request_id="r1")
+            assert logger.context[F.REQUEST_METHOD] == "POST"
+        assert logger.context == {}, "context should be empty after the scope exits"
+
+    def test_warm_invocation_does_not_inherit_prior_context(self):
+        logger = FakePowertoolsLogger()
+        binder = powertools_binder(logger)
+
+        # First (warm) invocation.
+        with binder.request_scope():
+            bind_user(binder, id="user-1", org_id="org-1")
+            logger.info("first")
+        first_fields = logger.records[-1]["fields"]
+        assert first_fields[F.USER_ID] == "user-1"
+
+        # Second invocation on the same warm container: must not see user-1.
+        with binder.request_scope():
+            bind_user(binder, id="user-2")
+            logger.info("second")
+        second_fields = logger.records[-1]["fields"]
+        assert second_fields[F.USER_ID] == "user-2"
+        assert F.USER_ORG_ID not in second_fields, "org-1 leaked into the next invocation"
+
+    def test_none_values_are_dropped(self):
+        logger = FakePowertoolsLogger()
+        binder = powertools_binder(logger)
+        with binder.request_scope():
+            bind_request(binder, method="GET", path=None, ip=None, request_id="r9")
+            assert F.REQUEST_METHOD in logger.context
+            assert F.REQUEST_PATH not in logger.context
+            assert F.REQUEST_IP not in logger.context
+
+    def test_scope_restores_prior_persistent_value(self):
+        # A key bound at process level (outside a scope) and rebound inside a scope
+        # is restored to its prior value on exit, not removed.
+        logger = FakePowertoolsLogger()
+        binder = powertools_binder(logger)
+        bind_build_context(binder, commit="startup-sha")  # process-level
+        with binder.request_scope():
+            bind_build_context(binder, commit="request-sha")
+            assert logger.context[F.GIT_COMMIT] == "request-sha"
+        assert logger.context[F.GIT_COMMIT] == "startup-sha", "prior value should be restored"
+
+    def test_scope_removes_keys_that_had_no_prior_value(self):
+        logger = FakePowertoolsLogger()
+        binder = powertools_binder(logger)
+        bind_build_context(binder, commit="startup-sha")  # process-level
+        with binder.request_scope():
+            bind_user(binder, id="u1")
+        assert F.USER_ID not in logger.context, "request-only key should be removed"
+        assert logger.context[F.GIT_COMMIT] == "startup-sha", "unrelated persistent key untouched"
+
+
+class TestStdlibBinder:
+    def test_bind_helpers_emit_dotted_keys(self):
+        logger, captured = _capturing_stdlib_logger("test.stdlib.emit")
+        binder = stdlib_binder(logger)
+        with binder.request_scope():
+            bind_request(binder, method="POST", path="/orders", request_id="r1")
+            bind_user(binder, id="u1", email="a@b.com", org_id="org9")
+            logger.info("response", extra={F.RESPONSE_STATUS: 200})
+        record = captured[-1]
+        assert getattr(record, F.REQUEST_METHOD) == "POST"
+        assert getattr(record, F.REQUEST_PATH) == "/orders"
+        assert getattr(record, F.USER_ORG_ID) == "org9"
+        assert getattr(record, F.RESPONSE_STATUS) == 200
+
+    def test_context_cleared_after_scope(self):
+        logger, captured = _capturing_stdlib_logger("test.stdlib.cleared")
+        binder = stdlib_binder(logger)
+        with binder.request_scope():
+            bind_request(binder, method="POST")
+        assert binder.current_fields() == {}
+        logger.info("after")
+        assert not hasattr(captured[-1], F.REQUEST_METHOD)
+
+    def test_context_injected_for_child_logger_records(self):
+        # A common layout: the binder is built on a parent logger that owns the
+        # handler, but records are emitted via child loggers (getLogger(__name__)).
+        parent = logging.getLogger("test.stdlib.parent")
+        parent.setLevel(logging.DEBUG)
+        parent.handlers = []
+        captured = []
+
+        class _Cap(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        parent.addHandler(_Cap())
+        binder = stdlib_binder(parent)
+
+        child = logging.getLogger("test.stdlib.parent.child")  # propagates to parent
+        with binder.request_scope():
+            bind_request(binder, method="POST", request_id="r1")
+            child.info("emitted via child logger")
+
+        assert getattr(captured[-1], F.REQUEST_METHOD) == "POST"
+        assert getattr(captured[-1], F.REQUEST_ID) == "r1"
+
+    def test_install_on_covers_handler_added_after_construction(self):
+        logger = logging.getLogger("test.stdlib.late-handler")
+        logger.setLevel(logging.DEBUG)
+        logger.handlers = []
+        binder = stdlib_binder(logger)  # no handler yet
+
+        captured = []
+
+        class _Cap(logging.Handler):
+            def emit(self, record):
+                captured.append(record)
+
+        handler = _Cap()
+        logger.addHandler(handler)
+        binder.install_on(handler)  # explicitly attach to the late handler
+
+        with binder.request_scope():
+            bind_request(binder, method="GET")
+            logger.info("after late handler")
+        assert getattr(captured[-1], F.REQUEST_METHOD) == "GET"
+
+    def test_explicit_extra_wins_over_bound_context(self):
+        logger, captured = _capturing_stdlib_logger("test.stdlib.override")
+        binder = stdlib_binder(logger)
+        with binder.request_scope():
+            bind_request(binder, method="GET")
+            logger.info("override", extra={F.REQUEST_METHOD: "POST"})
+        assert getattr(captured[-1], F.REQUEST_METHOD) == "POST"
+
+    def test_build_context_helper(self):
+        logger, captured = _capturing_stdlib_logger("test.stdlib.build")
+        binder = stdlib_binder(logger)
+        with binder.request_scope():
+            bind_build_context(binder, commit="abc123", branch="main")
+            logger.info("build")
+        record = captured[-1]
+        assert getattr(record, F.GIT_COMMIT) == "abc123"
+        assert getattr(record, F.GIT_BRANCH) == "main"
+        assert not hasattr(record, F.GIT_TAG)
+
+    def test_concurrent_request_scopes_do_not_leak(self):
+        """Two interleaved async requests must each keep only their own context."""
+        logger, _ = _capturing_stdlib_logger("test.stdlib.concurrent")
+        binder = stdlib_binder(logger)
+        results = {}
+
+        async def handle(user_id):
+            with binder.request_scope():
+                bind_user(binder, id=user_id, org_id=f"org-{user_id}")
+                # Yield control so the other task interleaves between bind and read.
+                await asyncio.sleep(0.01)
+                results[user_id] = binder.current_fields()
+
+        async def run():
+            await asyncio.gather(handle("A"), handle("B"))
+
+        asyncio.run(run())
+
+        assert results["A"] == {F.USER_ID: "A", F.USER_ORG_ID: "org-A"}
+        assert results["B"] == {F.USER_ID: "B", F.USER_ORG_ID: "org-B"}
+
+    def test_concurrent_scopes_do_not_leak_into_emitted_records(self):
+        """The contextvar filter must inject only the emitting task's fields."""
+        logger, captured = _capturing_stdlib_logger("test.stdlib.concurrent.emit")
+        binder = stdlib_binder(logger)
+
+        async def handle(user_id):
+            with binder.request_scope():
+                bind_user(binder, id=user_id)
+                await asyncio.sleep(0.01)
+                logger.info(f"msg-{user_id}")
+
+        async def run():
+            await asyncio.gather(handle("A"), handle("B"))
+
+        asyncio.run(run())
+
+        by_message = {r.getMessage(): getattr(r, F.USER_ID, None) for r in captured}
+        assert by_message == {"msg-A": "A", "msg-B": "B"}
+
+
+class TestLogException:
+    def test_sets_explicit_error_fields(self):
+        logger, captured = _capturing_stdlib_logger("test.logexc")
+        binder = stdlib_binder(logger)
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            log_exception(binder, exc, "handler failed")
+        record = captured[-1]
+        assert getattr(record, F.ERROR_TYPE) == "ValueError"
+        assert getattr(record, F.ERROR_MESSAGE) == "boom"
+        stack = getattr(record, F.ERROR_STACK)
+        assert "ValueError: boom" in stack
+        assert "Traceback" in stack
+
+    def test_does_not_duplicate_traceback_via_exc_info(self):
+        # Called inside an except block, log_exception must NOT set exc_info (which
+        # would make the backend emit its own traceback field on top of error.stack).
+        logger, captured = _capturing_stdlib_logger("test.logexc.noexcinfo")
+        binder = stdlib_binder(logger)
+        try:
+            raise ValueError("boom")
+        except ValueError as exc:
+            log_exception(binder, exc, "handler failed")
+        record = captured[-1]
+        assert record.levelno == logging.ERROR
+        assert record.exc_info is None, "must not carry exc_info (no duplicate backend traceback)"
+        assert record.exc_text is None
+        assert getattr(record, F.ERROR_STACK)  # trace lives solely in error.stack
+
+    def test_error_stack_is_set_not_left_to_backend(self):
+        """error.stack must be populated explicitly, not via exc_info alone."""
+        logger = FakePowertoolsLogger()
+        binder = powertools_binder(logger)
+        try:
+            raise KeyError("missing")
+        except KeyError as exc:
+            log_exception(binder, exc, "failed")
+        fields = logger.records[-1]["fields"]
+        assert F.ERROR_STACK in fields
+        assert fields[F.ERROR_STACK]  # non-empty
+
+
+class TestBodyHelpers:
+    def test_request_body_fields_redacts_and_serialises(self):
+        result = request_body_fields({"password": "x", "order_id": "O1"})
+        assert set(result) == {F.REQUEST_BODY_JSON}
+        payload = result[F.REQUEST_BODY_JSON]
+        assert "***REDACTED***" in payload
+        assert "O1" in payload
+        assert "x" not in payload
+
+    def test_response_output_fields_redacts_and_serialises(self):
+        result = response_output_fields({"token": "t", "status": "ok"})
+        assert set(result) == {F.RESPONSE_OUTPUT_JSON}
+        payload = result[F.RESPONSE_OUTPUT_JSON]
+        assert "***REDACTED***" in payload
+        assert "ok" in payload
+
+    def test_allow_only_is_honoured(self):
+        result = request_body_fields({"email": "person@example.com", "order_id": "O1"}, allow_only=["order_id"])
+        payload = result[F.REQUEST_BODY_JSON]
+        assert "O1" in payload
+        assert "person@example.com" not in payload  # value masked
+        assert "***REDACTED***" in payload
+
+    def test_deny_extra_is_forwarded(self):
+        result = request_body_fields({"internal_ref": "x", "order_id": "O1"}, deny_extra=["internal_ref"])
+        payload = result[F.REQUEST_BODY_JSON]
+        assert "***REDACTED***" in payload
+        assert "O1" in payload
+        assert "x" not in payload.replace("order_id", "")  # the ref value is gone
+
+    def test_custom_redactor_without_deny_extra_still_works(self):
+        # A custom redactor that does not accept deny_extra must not break when the
+        # caller does not pass deny_extra.
+        def only_keys(payload, *, allow_only=None):
+            return {"redacted": True}
+
+        result = request_body_fields({"a": 1}, redactor=only_keys)
+        assert '"redacted": true' in result[F.REQUEST_BODY_JSON]
+
+    def test_non_serialisable_values_do_not_raise(self):
+        class Custom:
+            def __str__(self):
+                return "custom-repr"
+
+        result = request_body_fields({"obj": Custom(), "n": 1})
+        assert "custom-repr" in result[F.REQUEST_BODY_JSON]

--- a/tests/test_logging_fields.py
+++ b/tests/test_logging_fields.py
@@ -1,0 +1,150 @@
+"""Tests for the structured-logging field registry and its derivations."""
+
+import pytest
+
+from nui_shared_utils.logging import (
+    FIELDS,
+    F,
+    Field,
+    alias_map,
+    redaction_keys,
+    validate_fields,
+    validate_registry,
+)
+from nui_shared_utils.logging.fields import _key_errors
+
+pytestmark = pytest.mark.unit
+
+
+class TestRegistryIntegrity:
+    def test_registry_is_internally_valid(self):
+        """The core registry passes its own import-time guard."""
+        assert validate_registry() == []
+
+    def test_registry_key_matches_field_key(self):
+        for key, fld in FIELDS.items():
+            assert key == fld.key, f"registry key {key!r} != Field.key {fld.key!r}"
+
+    def test_all_keys_are_dotted_snake_case(self):
+        for key in FIELDS:
+            assert _key_errors(key) == [], f"{key!r} is not a valid field name"
+
+    def test_all_types_are_known(self):
+        known = {"keyword", "text", "long", "boolean", "date", "geo_point"}
+        for fld in FIELDS.values():
+            assert fld.type in known, f"{fld.key}: unknown type {fld.type!r}"
+
+    def test_no_duplicate_keys(self):
+        # A dict cannot hold duplicate keys, so assert the F constants and the
+        # registry keys are a consistent 1:1 set instead.
+        f_values = [getattr(F, n) for n in dir(F) if not n.startswith("_") and isinstance(getattr(F, n), str)]
+        assert len(f_values) == len(set(f_values)), "duplicate value in F constants"
+
+    def test_every_F_constant_is_registered(self):
+        for name in dir(F):
+            if name.startswith("_"):
+                continue
+            value = getattr(F, name)
+            if isinstance(value, str):
+                assert value in FIELDS, f"F.{name} = {value!r} missing from FIELDS"
+
+    def test_aliases_are_globally_unique(self):
+        seen = {}
+        for key, fld in FIELDS.items():
+            for alias in fld.aliases:
+                assert alias not in seen, f"alias {alias!r} used by {seen.get(alias)!r} and {key!r}"
+                seen[alias] = key
+
+    def test_aliases_do_not_collide_with_canonical_keys(self):
+        for fld in FIELDS.values():
+            for alias in fld.aliases:
+                assert alias not in FIELDS, f"alias {alias!r} collides with a canonical field"
+
+    def test_field_is_frozen(self):
+        fld = FIELDS["user.email"]
+        with pytest.raises(Exception):
+            fld.key = "user.other"  # frozen dataclass -> FrozenInstanceError
+
+
+class TestKeyValidation:
+    @pytest.mark.parametrize(
+        "key",
+        ["target", "request.method", "user.org_id", "response.duration_ms", "git.commit"],
+    )
+    def test_valid_keys(self, key):
+        assert _key_errors(key) == []
+
+    @pytest.mark.parametrize(
+        "key",
+        ["orderId", "api_status.CODE", "request.device-os", "Request.method", "user..id", "9lives", ""],
+    )
+    def test_invalid_keys(self, key):
+        assert _key_errors(key) != []
+
+
+class TestValidateFields:
+    def test_valid_consumer_module(self):
+        class OrderFields:
+            ORDER_ID = "order.id"
+            ORDER_STATE = "order.state"
+            SINGLE = "target"
+
+        assert validate_fields(OrderFields) == []
+
+    def test_invalid_consumer_module_is_flagged(self):
+        class BadFields:
+            CAMEL = "orderId"
+            HYPHEN = "request.device-os"
+            GOOD = "order.id"
+
+        errors = validate_fields(BadFields)
+        assert any("orderId" in e for e in errors)
+        assert any("device-os" in e for e in errors)
+        assert not any("order.id" in e for e in errors)
+
+    def test_ignores_non_string_and_private_attrs(self):
+        class Mixed:
+            FIELD = "order.id"
+            _PRIVATE = "camelCase"  # ignored (underscore-prefixed)
+            COUNT = 5  # ignored (non-string)
+
+        assert validate_fields(Mixed) == []
+
+    def test_multiple_modules(self):
+        class A:
+            X = "a.one"
+
+        class B:
+            Y = "bad-name"
+
+        errors = validate_fields(A, B)
+        assert len(errors) == 1
+        assert "bad-name" in errors[0]
+
+
+class TestRedactionKeys:
+    def test_derives_pii_and_redact_leaf_names(self):
+        keys = redaction_keys()
+        assert "email" in keys  # user.email is pii
+        assert "body_json" in keys  # request.body_json is redact
+        assert "output_json" in keys  # response.output_json is redact
+
+    def test_excludes_non_sensitive_fields(self):
+        keys = redaction_keys()
+        assert "method" not in keys
+        assert "org_id" not in keys
+
+
+class TestAliasMap:
+    def test_maps_old_names_to_canonical_keys(self):
+        mapping = alias_map()
+        assert mapping["request.user"] == "user.email"
+        assert mapping["request.company"] == "user.org_id"
+        assert mapping["request.company_id"] == "user.org_id"
+        assert mapping["request.trace_id"] == "trace.id"
+        assert mapping["api.duration_ms"] == "response.duration_ms"
+        assert mapping["request.url"] == "request.path"
+
+    def test_every_alias_target_is_a_real_field(self):
+        for target in alias_map().values():
+            assert target in FIELDS

--- a/tests/test_redaction.py
+++ b/tests/test_redaction.py
@@ -1,0 +1,127 @@
+"""Tests for the log-payload redactor (deny-list default, allow-list opt-in)."""
+
+import copy
+
+import pytest
+
+from nui_shared_utils.logging import MASK, default_redactor
+
+pytestmark = pytest.mark.unit
+
+
+class TestDenyList:
+    def test_masks_top_level_secret(self):
+        assert default_redactor({"password": "hunter2", "ok": 1}) == {"password": MASK, "ok": 1}
+
+    def test_masks_nested_dict_secret(self):
+        payload = {"outer": {"token": "abc", "keep": "v"}}
+        assert default_redactor(payload) == {"outer": {"token": MASK, "keep": "v"}}
+
+    def test_masks_secret_inside_list(self):
+        payload = {"items": [{"api_key": "k"}, {"safe": "s"}]}
+        assert default_redactor(payload) == {"items": [{"api_key": MASK}, {"safe": "s"}]}
+
+    def test_separator_and_case_insensitive_match(self):
+        payload = {"apiKey": 1, "API_KEY": 2, "X-Api-Key": 3, "AccessToken": 4, "X-Auth-Token": 5}
+        redacted = default_redactor(payload)
+        assert all(v == MASK for v in redacted.values())
+
+    def test_whole_word_matching_avoids_false_positives(self):
+        # Deny tokens must match on word boundaries only: "card" / "auth" / "pin"
+        # should NOT mask these unrelated keys.
+        payload = {"wildcard": 1, "author": 2, "mapping": 3, "shipping_status": 4}
+        assert default_redactor(payload) == payload
+
+    def test_prefixed_and_suffixed_sensitive_words_are_masked(self):
+        payload = {"card_number": 1, "user_password": 2, "refresh_token": 3}
+        redacted = default_redactor(payload)
+        assert all(v == MASK for v in redacted.values())
+
+    def test_concatenated_lowercase_secret_keys_are_masked(self):
+        # No delimiter, no camelCase: caught by the curated substring pass.
+        payload = {"accesstoken": 1, "apitoken": 2, "sessiontoken": 3, "privatekey": 4, "userpassword": 5}
+        redacted = default_redactor(payload)
+        assert all(v == MASK for v in redacted.values())
+
+    def test_substring_pass_does_not_mask_innocent_keys(self):
+        # "key" is deliberately NOT in the substring set, so these survive.
+        payload = {"monkey": 1, "primary_key": 2, "keyboard_layout": 3}
+        redacted = default_redactor(payload)
+        assert redacted["monkey"] == 1
+        assert redacted["keyboard_layout"] == 3
+        # primary_key: "key" is not a substring-deny token and not a whole word match
+        assert redacted["primary_key"] == 2
+
+    def test_auth_jwt_bearer_masked_without_false_positives(self):
+        redacted = default_redactor(
+            {"auth": 1, "jwt": 2, "bearer_token": 3, "x_auth": 4, "author": "keep", "authored_by": "keep"}
+        )
+        assert redacted["auth"] == MASK
+        assert redacted["jwt"] == MASK
+        assert redacted["bearer_token"] == MASK
+        assert redacted["x_auth"] == MASK
+        assert redacted["author"] == "keep"  # single word, not "auth"
+        assert redacted["authored_by"] == "keep"
+
+    def test_email_variants_masked_but_not_similar_words(self):
+        redacted = default_redactor({"user_email": "e", "emailer_config": "keep"})
+        assert redacted["user_email"] == MASK  # ..._email -> masked
+        assert redacted["emailer_config"] == "keep"  # single word "emailer" != "email"
+
+    def test_registry_derived_pii_key_is_masked(self):
+        # user.email is sensitivity=pii, so its leaf name "email" is in the deny set.
+        assert default_redactor({"email": "a@b.com"}) == {"email": MASK}
+
+    def test_deny_extra_extends_the_set(self):
+        payload = {"custom_secret_field": "x", "note": "n"}
+        redacted = default_redactor(payload, deny_extra=["custom_secret_field"])
+        assert redacted == {"custom_secret_field": MASK, "note": "n"}
+
+    def test_non_sensitive_keys_survive(self):
+        payload = {"order_id": "O1", "status": "confirmed", "count": 3}
+        assert default_redactor(payload) == payload
+
+
+class TestAllowList:
+    def test_keeps_only_named_keys(self):
+        payload = {"order_id": 1, "secret_note": "s", "email": "e", "status": "ok"}
+        redacted = default_redactor(payload, allow_only=["order_id", "status"])
+        assert redacted == {"order_id": 1, "secret_note": MASK, "email": MASK, "status": "ok"}
+
+    def test_allow_list_applies_at_every_depth(self):
+        payload = {"keep": {"keep": 1, "drop": 2}}
+        redacted = default_redactor(payload, allow_only=["keep"])
+        assert redacted == {"keep": {"keep": 1, "drop": MASK}}
+
+    def test_deny_list_still_wins_over_allow(self):
+        # A key explicitly allowed but also sensitive is still masked (backstop).
+        payload = {"password": "x", "order_id": 1}
+        redacted = default_redactor(payload, allow_only=["password", "order_id"])
+        assert redacted == {"password": MASK, "order_id": 1}
+
+
+class TestNoMutation:
+    def test_caller_dict_is_not_mutated(self):
+        payload = {"password": "hunter2", "nested": {"token": "abc"}, "list": [{"secret": "s"}]}
+        original = copy.deepcopy(payload)
+        default_redactor(payload)
+        assert payload == original
+
+    def test_result_is_a_distinct_structure(self):
+        payload = {"nested": {"keep": 1}}
+        redacted = default_redactor(payload)
+        assert redacted is not payload
+        assert redacted["nested"] is not payload["nested"]
+
+
+class TestNonDictPayloads:
+    @pytest.mark.parametrize("value", ["hello", 42, 3.14, True, None])
+    def test_scalars_pass_through(self, value):
+        assert default_redactor(value) == value
+
+    def test_top_level_list(self):
+        assert default_redactor([{"password": 1}, {"ok": 2}]) == [{"password": MASK}, {"ok": 2}]
+
+    def test_empty_containers(self):
+        assert default_redactor({}) == {}
+        assert default_redactor([]) == []


### PR DESCRIPTION
## What this adds

A structured-logging contract: one canonical, dotted, snake_case field vocabulary
that services and Lambda functions import, plus helpers that emit it. Structured
logs across a fleet drift into incompatible shapes (flat `order_id`, dotted
`request.order_id`, nested `{"request": {...}}`, message-only). This is a
producer-side problem whose cost is store-neutral: a schema-enforcing store turns
drift into loud mapping conflicts and silent nulls, and a schema-less store accepts
it silently and lets queries/alerts skew. This gives callers one shape to target.

New subpackage `nui_shared_utils.logging` (standard-library only, so importing it
pulls in no boto3 / elasticsearch / slack / powertools):

- **Field registry** (`FIELDS`, `F`, `Field`): each canonical field carries its
  type (producer intent), indexed flag, sensitivity, and deprecated aliases. Covers `request.*`,
  `user.*`, `response.*`, `route.*`, `error.*`, `trace.*`, `git.*`, `target`, and
  the opaque `request.body_json` / `response.output_json` retrieval fields. Domain
  fields (`order.*`, etc.) stay in the consumer and are drift-checked with
  `validate_fields(...)`.
- **Backend-agnostic, request-scoped binders**: `powertools_binder(logger)` (over an
  AWS Powertools `Logger`) and `stdlib_binder(logger)` (a `contextvars`-backed
  `logging.Filter`). `binder.request_scope()` clears bound context on exit so it
  cannot leak across concurrent requests on a long-running service or across warm
  Lambda invocations.
- **Binding helpers**: `bind_request`, `bind_user`, `bind_build_context`,
  `log_exception` (sets `error.stack` explicitly), and `request_body_fields` /
  `response_output_fields` that redact and serialise unbounded payloads into a single
  string field.
- **Redaction** (`default_redactor`): recursive, deny-list by default (masks
  `password` / `token` / `authorization` / `api_key` / ... by whole snake_case word,
  so header variants like `X-Api-Key` match but `wildcard` does not), allow-list opt-in
  for PII-heavy routes. Never mutates the caller's payload.
- **Derive-once helpers**: `redaction_keys()` (deny set) and `alias_map()` (old→new
  migration map), both derived from the one registry.

Wire shape is **dotted**, not nested dicts: dotted keys survive Powertools
`append_keys` incremental binding where nested dicts clobber (a producer-side
property, independent of the log store). The contract is deliberately store-neutral,
it governs how services emit fields, not how any store indexes them. Rationale in
`docs/decisions/ADR-001-structured-logging-field-vocabulary.md`.

## Docs

- New guide: `docs/guides/structured-logging-contract.md`.
- ADR-001 (Proposed).
- Aligned the inconsistent flat-key `extra=` examples in
  `docs/guides/powertools-integration.md` with the contract.

## Test plan

- [x] 77 new unit tests: registry validation + derivations, redaction (no-mutation,
  nested/list descent, deny/allow precedence, word-boundary + concatenated-key matching),
  Powertools warm-invocation unbind + prior-value restore, stdlib concurrent-request
  isolation (async) and child-logger propagation, binding helpers, and `log_exception`
  setting `error.stack` without a duplicate backend traceback.
- [x] Cold-import regression tests: the logging contract imports no heavy dependency and
  is not eagerly loaded by `import nui_shared_utils`.
- [x] Full suite green for the new code (2 pre-existing, unrelated `test_slack_client`
  ordering failures exist on the base branch and are out of scope here).
- [x] `black --check` and `mypy` clean on the new module.

## Backwards compatibility

Additive only. New public symbols are exported lazily from `nui_shared_utils` (and
forwarded by the legacy `nui_lambda_shared_utils` shim). No existing API changes; the
registry is opt-in and adopting it is per-consumer. Version is derived from git tags
(setuptools-scm), so no manual version bump.
