### PR TITLE
ci: drop unused TestPyPI publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -108,31 +108,3 @@ jobs:
         verbose: true
         print-hash: true
         skip-existing: true  # No-op instead of failing if the version is already on PyPI (safe re-runs)
-
-  publish-test:
-    name: Publish to TestPyPI
-    runs-on: ubuntu-latest
-    needs: [test, build]
-    # Publish to TestPyPI on manual (non-tag) dispatch only; tag pushes go to PyPI above
-    if: github.event_name == 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/project/nui-python-shared-utils/
-    
-    permissions:
-      id-token: write
-      contents: read
-    
-    steps:
-    - name: Download artifacts
-      uses: actions/download-artifact@v7
-      with:
-        name: dist
-        path: dist/
-    
-    - name: Publish to TestPyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        repository-url: https://test.pypi.org/legacy/
-        verbose: true
-        print-hash: true


### PR DESCRIPTION
## Summary
- Remove the `publish-test` job that pushed to TestPyPI on manual dispatch.
- It relied on a PyPI trusted publisher that was never configured on TestPyPI, so every manual `workflow_dispatch` run failed at the OIDC token exchange with `invalid-publisher`. The path was never usable.
- The release path is unchanged: tagged pushes still publish to PyPI via the `publish` job (gated on `refs/tags/`). `workflow_dispatch` still runs tests and builds the dist.

## Changes
- `.github/workflows/publish.yml`: delete the `publish-test` job (and its `testpypi` environment reference).

## Test plan
- [x] `python -c "import yaml; yaml.safe_load(open('.github/workflows/publish.yml'))"` parses clean
- [x] No remaining references to `publish-test` / TestPyPI in `.github/`
- [x] `publish` job (tag → PyPI) and `test` / `build` jobs unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Re-running a package release will no longer fail when the same version is already published.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->