### PR TITLE
fix(elasticsearch): support client majors 7.17, 8.x and 9.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,39 @@ jobs:
         name: codecov-umbrella
         fail_ci_if_error: false
 
+  es-compat:
+    name: Elasticsearch client ${{ matrix.elasticsearch-version }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Every major the [elasticsearch] extra allows. The ES tests drive the
+        # real client with a stubbed transport, so a call shape that a major
+        # stops accepting fails here.
+        elasticsearch-version: ['7.17.*', '8.*', '9.*']
+
+    steps:
+    - uses: actions/checkout@v5
+      with:
+        persist-credentials: false
+
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: '3.11'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pytest pytest-mock
+        pip install -e .
+        pip install "elasticsearch==${{ matrix.elasticsearch-version }}"
+        python -c "import elasticsearch; print('elasticsearch', elasticsearch.__version__)"
+
+    - name: Test Elasticsearch client
+      run: |
+        pytest tests/test_es_client.py tests/test_es_client_compat.py tests/test_es_query_builder.py -v
+
   build:
     name: Build Package
     runs-on: ubuntu-latest

--- a/docs/decisions/ADR-007-elasticsearch-client-version-range.md
+++ b/docs/decisions/ADR-007-elasticsearch-client-version-range.md
@@ -1,0 +1,83 @@
+# ADR-007: Support elasticsearch-py 7.17, 8.x and 9.x from one call shape
+
+**Status**: Proposed
+**Date**: 2026-07-27
+
+## Context
+
+The `[elasticsearch]` extra selects the client library a consumer installs alongside this
+package. Because an extra is a hard requirement range, a narrow range is not a
+conservative default: it is a wall. A consumer already on `elasticsearch>=8` cannot install
+`nui-python-shared-utils[elasticsearch]` at all if the extra caps at `<8` -- the resolver
+fails outright rather than degrading. Consumers span clusters of different vintages, so any
+single-major range excludes part of the audience.
+
+The client majors differ in how a request body is passed:
+
+- **7.17** takes the whole request as `body=`, with URL parameters (`size`, `ignore_unavailable`)
+  as separate keywords. It emits a deprecation warning for `body=` pointing at 8.x.
+- **8.x / 9.x** expose body fields as first-class keywords (`query=`, `aggs=`, `size=`) and keep
+  `body=` as a raw escape hatch. Mixing the two forms is the trap: passing `body=` *and* a body
+  field as a keyword folds that keyword into the caller's dict (mutating it in place) and raises
+  `ValueError: Received multiple values for 'size'` if the key is already present. So
+  `search(index=..., body=body, size=n)` works once, then fails the second time the same body
+  dict is reused with a different size.
+
+That mixed form is what `es_client` sent, which means the `<8` cap was not merely stale: the
+code as written was correct only for 7.x.
+
+## Decision
+
+The `[elasticsearch]` extra allows `>=7.17.0,<10.0.0`, and `es_client` sends the one call
+shape all three majors accept: `size` folded into a **copy** of the caller's body
+(`_body_with_size`), passed as `body=` with only genuine URL parameters
+(`ignore_unavailable`) as keywords. No version sniffing, no branching.
+
+- `search` / `aggregate` carry `size` inside the body copy; an explicit `size` argument wins
+  over a `size` already in the body, and the caller's dict is never mutated.
+- `count`, `cat.indices`, `info` and `cluster.health` already used a form valid on every major.
+- `get_indices_info` normalises the 8.x/9.x response wrapper to a plain `list`.
+
+`tests/test_es_client_compat.py` drives the real client with a stubbed transport (no server),
+so an incompatible call shape fails as a test rather than in a consumer's Lambda. The CI
+`es-compat` matrix runs it against 7.17, 8.x and 9.x.
+
+The `<10` ceiling is the untested next major, not a known incompatibility.
+
+## Alternatives considered
+
+- **Cap at `<8` and tell consumers to pin down.** The status quo. Rejected: it forecloses the
+  extra for anyone on a current client, and the resolver failure (`ResolutionImpossible`) gives
+  no path forward short of forking.
+- **Move to `>=8` only and use the native keyword API** (`query=`, `aggs=`, `size=`). Cleaner
+  code, and drops a deprecated form. Rejected because it moves the wall rather than removing
+  it: consumers on 7.17 clusters would be the ones locked out, and this package exists to be
+  installable next to what a consumer already runs.
+- **Detect the installed major at runtime and branch** (`body=` on 7.x, keywords on 8/9).
+  Rejected: two call paths, one of which is exercised only on whichever major CI happens to
+  install, for no behavioural gain over a shape that is already valid everywhere.
+- **Mock-only tests.** The existing ES tests replace `Elasticsearch` with a `Mock`, which pins
+  our call shape but cannot tell whether the installed client accepts it -- precisely the bug
+  class here. Hence the stubbed-transport tests against the real client.
+
+## Consequences
+
+- The extra installs alongside 7.17, 8.x or 9.x, so the ES helpers are reusable by consumers on
+  current clients instead of only legacy ones.
+- Body dicts are safe to reuse across calls on every major; the 8.x/9.x in-place mutation is gone.
+- `size` is a body field in the request we send. A consumer reading the wire format sees it in
+  the body rather than the query string, on every major.
+- The compat tests bind us to the real client's request-building layer, so a breaking change in a
+  future client shows up as a CI failure in the `es-compat` job.
+
+## Load-bearing premises (supersede triggers)
+
+- **`body=` remains a supported escape hatch on 8.x/9.x.** It is documented as such today. If a
+  future major removes it, the single-shape decision breaks and the choice becomes: drop 7.x and
+  move to the keyword API, or branch by version.
+- **Consumers still run 7.17 clients.** The whole cost here is keeping a deprecated call form
+  alive. Once no supported consumer needs 7.x, raising the floor to `>=8` and moving to the
+  native keyword API is strictly simpler.
+- **The extra's range is a hard constraint on the consumer's environment.** If the ES helpers
+  ever moved behind a runtime-optional import with no declared range, the reasoning for a wide
+  range would change.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -29,3 +29,4 @@ Keep each ADR under two pages. Longer than that means it is a plan, not an ADR.
 | [004](ADR-004-credential-resolution-precedence.md) | Credential resolution precedence: explicit dict, then env vars, then Secrets Manager | Proposed | 2026-07-13 |
 | [005](ADR-005-explicit-secrets-manager-region.md) | Resolve the Secrets Manager region explicitly (session, then env); no hidden default, fail loud | Proposed | 2026-07-13 |
 | [006](ADR-006-snowflake-sql-api-client.md) | Snowflake access via the pure-Python SQL API client, not the native connector | Proposed | 2026-07-13 |
+| [007](ADR-007-elasticsearch-client-version-range.md) | Support elasticsearch-py 7.17, 8.x and 9.x from one call shape | Proposed | 2026-07-27 |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -67,7 +67,11 @@ pip install -e .[dev]
 
 #### elasticsearch
 
-- `elasticsearch>=7.17.0,<8.0.0` - Elasticsearch client
+- `elasticsearch>=7.17.0,<10.0.0` - Elasticsearch client
+
+  Client majors 7.17, 8.x and 9.x are all supported and tested; pick whichever
+  your cluster needs. The `<10` ceiling is the untested next major, not a known
+  incompatibility. See [ADR-007](../decisions/ADR-007-elasticsearch-client-version-range.md).
 
 #### database
 

--- a/docs/guides/elasticsearch-integration.md
+++ b/docs/guides/elasticsearch-integration.md
@@ -35,6 +35,23 @@ Install with the elasticsearch extra:
 pip install nui-python-shared-utils[elasticsearch]
 ```
 
+### Supported client versions
+
+The extra allows `elasticsearch>=7.17.0,<10.0.0`. Client majors 7.17, 8.x and 9.x are all
+supported and covered by CI, so the extra installs alongside whichever client your cluster
+needs. `ElasticsearchClient` sends one request form that every one of those majors accepts;
+`size` travels inside the request body rather than as a separate argument, and your body dict
+is copied, never mutated, so it is safe to reuse across calls.
+
+Pin the client yourself if you need a specific major:
+
+```bash
+pip install nui-python-shared-utils[elasticsearch] "elasticsearch<9"
+```
+
+See [ADR-007](../decisions/ADR-007-elasticsearch-client-version-range.md) for the reasoning
+and the `<10` ceiling.
+
 ## Configuration
 
 ### AWS Secrets Manager Setup

--- a/nui_shared_utils/es_client.py
+++ b/nui_shared_utils/es_client.py
@@ -97,24 +97,37 @@ class ElasticsearchClient(BaseClient, ServiceHealthMixin):
             retry_on_timeout=self.client_config.get("retry_on_timeout", True),
         )
 
+    @staticmethod
+    def _body_with_size(body: Dict, size: int) -> Dict:
+        """Return a copy of ``body`` carrying ``size``.
+
+        ``size`` travels inside the request body rather than as a sibling keyword
+        argument, which is the one call shape every supported client major accepts.
+        On elasticsearch-py 8.x/9.x, passing ``body=`` alongside a body field as a
+        keyword folds that keyword into the caller's dict (mutating it) and raises
+        ``ValueError`` if the key is already there, so reusing a body dict for two
+        searches breaks. A body that carries its own ``size`` is accepted unchanged
+        by 7.17, 8.x and 9.x, and leaves the caller's dict alone.
+        """
+        return {**body, "size": size}
+
     @handle_client_errors(default_return=[])
     def search(self, index: str, body: Dict, size: int = 100) -> List[Dict]:
         """
         Execute search query with error handling.
-        
+
         Args:
             index: Index pattern to search
             body: Elasticsearch query body
-            size: Maximum results to return
-            
+            size: Maximum results to return (overrides any ``size`` in ``body``)
+
         Returns:
             List of hit documents
         """
         def _search_operation():
             response = self._service_client.search(
                 index=index,
-                body=body,
-                size=size,
+                body=self._body_with_size(body, size),
                 ignore_unavailable=True
             )
             return [hit["_source"] for hit in response["hits"]["hits"]]
@@ -141,8 +154,7 @@ class ElasticsearchClient(BaseClient, ServiceHealthMixin):
         def _aggregate_operation():
             response = self._service_client.search(
                 index=index,
-                body=body,
-                size=0,  # Only need aggregations
+                body=self._body_with_size(body, 0),  # Only need aggregations
                 ignore_unavailable=True
             )
             return response.get("aggregations", {})
@@ -374,7 +386,9 @@ class ElasticsearchClient(BaseClient, ServiceHealthMixin):
                 format="json",
                 h="index,health,status,docs.count,store.size"
             )
-            return response or []
+            # 8.x/9.x return a response wrapper around the JSON array; normalise to
+            # a plain list so callers get the same type on every client major.
+            return list(response) if response else []
 
         return self._execute_with_error_handling(
             "get_indices_info",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,10 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-elasticsearch = ["elasticsearch>=7.17.0,<8.0.0"]
+# Client majors 7.17, 8.x and 9.x are all supported: es_client sends one call
+# shape that is valid on each (see ADR-007). The <10 ceiling is the untested
+# next major, not a known incompatibility.
+elasticsearch = ["elasticsearch>=7.17.0,<10.0.0"]
 database = ["pymysql>=1.0.0", "psycopg2-binary>=2.9.0"]
 slack = ["slack-sdk>=3.19.0"]
 powertools = [
@@ -55,7 +58,7 @@ snowflake = [
 # and opt-in. Keep in sync with setup.py.
 llm = ["anthropic[bedrock]>=0.45.0,<1.0.0"]
 all = [
-    "elasticsearch>=7.17.0,<8.0.0",
+    "elasticsearch>=7.17.0,<10.0.0",
     "pymysql>=1.0.0",
     "psycopg2-binary>=2.9.0",
     "slack-sdk>=3.19.0",

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -19,7 +19,9 @@ types-pytz>=2023.3.0
 types-PyYAML>=6.0.0
 
 # Optional dependencies for testing
-elasticsearch>=7.17.0,<8.0.0
+# Matches the [elasticsearch] extra range; the es-compat CI job pins each major
+# in turn (7.17 / 8.x / 9.x).
+elasticsearch>=7.17.0,<10.0.0
 pymysql>=1.0.0
 psycopg2-binary>=2.9.0
 slack-sdk>=3.19.0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,10 @@ setup(
         "pyyaml>=6.0",
     ],
     extras_require={
-        "elasticsearch": ["elasticsearch>=7.17.0,<8.0.0"],
+        # Client majors 7.17, 8.x and 9.x are all supported: es_client sends one
+        # call shape that is valid on each (see docs/decisions/ADR-007). The <10
+        # ceiling is the untested next major, not a known incompatibility.
+        "elasticsearch": ["elasticsearch>=7.17.0,<10.0.0"],
         "database": ["pymysql>=1.0.0", "psycopg2-binary>=2.9.0"],
         "slack": ["slack-sdk>=3.19.0"],
         "powertools": [
@@ -67,7 +70,7 @@ setup(
         # SDK is specialized and opt-in. Keep in sync with pyproject.toml.
         "llm": ["anthropic[bedrock]>=0.45.0,<1.0.0"],
         "all": [
-            "elasticsearch>=7.17.0,<8.0.0",
+            "elasticsearch>=7.17.0,<10.0.0",
             "pymysql>=1.0.0",
             "psycopg2-binary>=2.9.0",
             "slack-sdk>=3.19.0",

--- a/tests/test_es_client.py
+++ b/tests/test_es_client.py
@@ -96,7 +96,7 @@ class TestSearch:
         assert results[1] == {"field2": "value2"}
 
         mock_client.search.assert_called_once_with(
-            index="test-index", body={"query": {"match_all": {}}}, size=100, ignore_unavailable=True
+            index="test-index", body={"query": {"match_all": {}}, "size": 100}, ignore_unavailable=True
         )
 
     @patch("nui_shared_utils.base_client.get_secret")
@@ -111,7 +111,42 @@ class TestSearch:
         client = ElasticsearchClient()
         client.search("test-index", {}, size=500)
 
-        mock_client.search.assert_called_once_with(index="test-index", body={}, size=500, ignore_unavailable=True)
+        mock_client.search.assert_called_once_with(index="test-index", body={"size": 500}, ignore_unavailable=True)
+
+    @patch("nui_shared_utils.base_client.get_secret")
+    @patch("nui_shared_utils.es_client.Elasticsearch")
+    def test_search_does_not_mutate_caller_body(self, mock_es, mock_get_secret):
+        """Search leaves the caller's body dict untouched so it can be reused."""
+        mock_get_secret.return_value = {"username": "elastic", "password": "pass"}
+        mock_client = Mock()
+        mock_es.return_value = mock_client
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        body = {"query": {"match_all": {}}}
+
+        client = ElasticsearchClient()
+        client.search("test-index", body, size=10)
+        client.search("test-index", body, size=20)
+
+        assert body == {"query": {"match_all": {}}}
+        assert mock_client.search.call_args_list[0][1]["body"]["size"] == 10
+        assert mock_client.search.call_args_list[1][1]["body"]["size"] == 20
+
+    @patch("nui_shared_utils.base_client.get_secret")
+    @patch("nui_shared_utils.es_client.Elasticsearch")
+    def test_search_size_argument_wins_over_body_size(self, mock_es, mock_get_secret):
+        """An explicit size argument overrides a size already in the body."""
+        mock_get_secret.return_value = {"username": "elastic", "password": "pass"}
+        mock_client = Mock()
+        mock_es.return_value = mock_client
+        mock_client.search.return_value = {"hits": {"hits": []}}
+
+        client = ElasticsearchClient()
+        client.search("test-index", {"query": {"match_all": {}}, "size": 5}, size=50)
+
+        mock_client.search.assert_called_once_with(
+            index="test-index", body={"query": {"match_all": {}}, "size": 50}, ignore_unavailable=True
+        )
 
     @patch("nui_shared_utils.base_client.get_secret")
     @patch("nui_shared_utils.es_client.Elasticsearch")
@@ -154,8 +189,10 @@ class TestAggregate:
 
         mock_client.search.assert_called_once_with(
             index="test-index",
-            body={"aggs": {"total_count": {"sum": {"field": "count"}}, "avg_value": {"avg": {"field": "value"}}}},
-            size=0,
+            body={
+                "aggs": {"total_count": {"sum": {"field": "count"}}, "avg_value": {"avg": {"field": "value"}}},
+                "size": 0,
+            },
             ignore_unavailable=True,
         )
 
@@ -255,7 +292,7 @@ class TestGetServiceStats:
         # Verify the search was called with correct parameters
         call_args = mock_client.search.call_args
         assert call_args[1]["index"] == "logs-order-*"
-        assert call_args[1]["size"] == 0
+        assert call_args[1]["body"]["size"] == 0
 
         # Verify time range in query
         query = call_args[1]["body"]["query"]["bool"]["filter"][0]["range"]["@timestamp"]

--- a/tests/test_es_client_compat.py
+++ b/tests/test_es_client_compat.py
@@ -1,0 +1,159 @@
+"""Compatibility tests for es_client against the installed elasticsearch-py client.
+
+The other ES tests replace ``Elasticsearch`` with a ``Mock``, which pins the call
+shape we send but cannot tell whether the installed client accepts it. These drive
+the *real* client with a stubbed transport (no server, no network), so they fail if
+our call shape stops being valid on the installed major.
+
+Supported majors: 7.17, 8.x and 9.x. The CI ``es-compat`` job runs this file
+against each in turn.
+"""
+
+import json
+import warnings
+
+import pytest
+
+pytestmark = pytest.mark.unit
+
+import elasticsearch
+
+from nui_shared_utils.es_client import ElasticsearchClient
+
+ES_MAJOR = elasticsearch.__version__[0]
+
+SEARCH_PAYLOAD = {
+    "hits": {"hits": [{"_source": {"field1": "value1"}}, {"_source": {"field2": "value2"}}]},
+    "aggregations": {"total": {"value": 3}},
+}
+
+
+class RequestRecorder:
+    """Stub transport that records requests and replays a canned payload."""
+
+    def __init__(self, payload):
+        self.payload = payload
+        self.requests = []
+
+    def __call__(self, *args, **kwargs):
+        method, target = args[0], args[1]
+        body = kwargs.get("body", args[4] if len(args) > 4 else None)
+        self.requests.append({"method": method, "target": target, "body": body})
+        if ES_MAJOR >= 8:
+            from elastic_transport import ApiResponseMeta, TransportApiResponse
+
+            meta = ApiResponseMeta(
+                status=200,
+                http_version="1.1",
+                headers={"x-elastic-product": "Elasticsearch"},
+                duration=0.0,
+                node=None,
+            )
+            return TransportApiResponse(meta, self.payload)
+        return self.payload
+
+    @property
+    def last(self):
+        return self.requests[-1]
+
+    def sent_body(self, index=-1):
+        """Return the request body as a dict, whichever form the client serialised it in."""
+        body = self.requests[index]["body"]
+        if isinstance(body, (bytes, str)):
+            return json.loads(body)
+        return body or {}
+
+
+def build_client(payload):
+    """Real ElasticsearchClient wired to a stub transport."""
+    client = ElasticsearchClient(
+        host="localhost:9200",
+        credentials={"username": "elastic", "password": "pass"},
+    )
+    recorder = RequestRecorder(payload)
+    client._service_client.transport.perform_request = recorder
+    return client, recorder
+
+
+@pytest.fixture
+def no_mixed_body_warning():
+    """Fail on the 8.x/9.x warning raised when body= is mixed with body-field keywords.
+
+    Narrow by design: it only catches the warning form. The 8.x/9.x hard failure
+    (``ValueError: Received multiple values for 'size'``) is swallowed by
+    ``handle_client_errors``, so the result assertions in each test catch that.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        yield
+    offenders = [
+        str(w.message)
+        for w in caught
+        if "in the presence of a 'body' parameter" in str(w.message) or "Received multiple values" in str(w.message)
+    ]
+    assert not offenders, f"call shape mixes body and body-field keywords: {offenders}"
+
+
+class TestInstalledClientAcceptsOurCalls:
+    """Every call es_client makes must be valid on the installed client major."""
+
+    def test_constructor_kwargs_accepted(self):
+        client, _ = build_client(SEARCH_PAYLOAD)
+        assert isinstance(client._service_client, elasticsearch.Elasticsearch)
+
+    def test_search(self, no_mixed_body_warning):
+        client, recorder = build_client(SEARCH_PAYLOAD)
+
+        results = client.search("test-index-*", {"query": {"match_all": {}}}, size=25)
+
+        # An empty list means the client rejected the call: handle_client_errors
+        # swallows the exception and returns the default.
+        assert results == [{"field1": "value1"}, {"field2": "value2"}]
+        assert recorder.sent_body()["size"] == 25
+        assert "test-index-*" in recorder.last["target"]
+
+    def test_search_reuses_the_same_body_dict(self, no_mixed_body_warning):
+        """Two searches from one body dict: mutating clients break the second call."""
+        client, recorder = build_client(SEARCH_PAYLOAD)
+        body = {"query": {"match_all": {}}}
+
+        first = client.search("test-index-*", body, size=10)
+        second = client.search("test-index-*", body, size=20)
+
+        assert first and second
+        assert recorder.sent_body(0)["size"] == 10
+        assert recorder.sent_body(1)["size"] == 20
+        assert body == {"query": {"match_all": {}}}, "caller's body dict was mutated"
+
+    def test_aggregate(self, no_mixed_body_warning):
+        client, recorder = build_client(SEARCH_PAYLOAD)
+
+        aggs = client.aggregate("test-index-*", {"aggs": {"total": {"cardinality": {"field": "id"}}}})
+
+        assert aggs == {"total": {"value": 3}}
+        assert recorder.sent_body()["size"] == 0
+
+    def test_count(self, no_mixed_body_warning):
+        client, recorder = build_client({"count": 42})
+
+        assert client.count("test-index-*", {"query": {"match_all": {}}}) == 42
+        assert recorder.sent_body() == {"query": {"match_all": {}}}
+
+        assert client.count("test-index-*") == 42  # body=None
+
+    def test_get_indices_info_returns_plain_list(self):
+        client, _ = build_client([{"index": "test-index", "health": "green"}])
+
+        indices = client.get_indices_info("test-*")
+
+        assert type(indices) is list
+        assert indices == [{"index": "test-index", "health": "green"}]
+
+    def test_get_cluster_info(self):
+        client, _ = build_client({"version": {"number": "8.19.0"}, "cluster_name": "c", "status": "green"})
+
+        info = client.get_cluster_info()
+
+        assert info["version"] == "8.19.0"
+        assert info["cluster_status"] == "green"
+        assert "error" not in info


### PR DESCRIPTION
## Summary

- The `[elasticsearch]` extra (and `all`) now allows `elasticsearch>=7.17.0,<10.0.0`, up from `<8.0.0`. A consumer already on an 8.x or 9.x client could not install `nui-python-shared-utils[elasticsearch]` at all: the ranges do not overlap, so the resolver fails outright rather than degrading.
- The old cap was hiding a real incompatibility rather than protecting against one. `es_client` called `search(index=..., body=body, size=n)`, mixing the raw-body form with a body field passed as a keyword. On 8.x/9.x that folds `size` into the **caller's** body dict (mutating it in place) and raises `ValueError: Received multiple values for 'size'` the second time the same dict is used.
- `search()` / `aggregate()` now fold `size` into a copy of the body and pass `body=` with only genuine URL parameters as keywords. One call shape that 7.17, 8.x and 9.x all accept, no version sniffing, and the caller's dict is left alone.
- `get_indices_info()` returns a plain `list` on every major (8.x/9.x wrap the JSON array in a response object).
- New `tests/test_es_client_compat.py` drives the real client through a stubbed transport (no server, no network). The existing ES tests mock `Elasticsearch` wholesale, so they pin our call shape but cannot see whether the installed client accepts it, which is exactly this bug class. A CI `es-compat` matrix runs it against each supported major.

Closes #37

## Backwards compatibility

Compatible for callers. Public signatures are unchanged.

- `search(index, body, size)` and `aggregate(index, body)` behave as before: an explicit `size` argument still wins over a `size` already present in `body` (it did before too, as a URL parameter overriding the body). It now travels in the request body instead of the query string.
- Body dicts passed to `search()` / `aggregate()` are no longer mutated. Code that (accidentally) relied on the client writing `size` back into its dict would see a change; nothing in this package did.
- `get_indices_info()` returns `list` instead of the client's response wrapper on 8.x/9.x. Iteration and indexing are unaffected.
- No change for consumers pinned to a 7.x client: the widened range only adds room above.

## Review

Internal: verified empirically against real installs of 7.17.13, 8.19.3 and 9.4.1. External: one clean pass (no correctness findings); two suggestions applied (fixture naming, count-body assertion).

## Changes

```
 .github/workflows/ci.yml                           |  33 +++++
 docs/decisions/ADR-007-...-version-range.md        |  83 +++++++++++
 docs/decisions/README.md                           |   1 +
 docs/getting-started/installation.md               |   6 +-
 docs/guides/elasticsearch-integration.md           |  17 +++
 nui_shared_utils/es_client.py                      |  30 ++--
 pyproject.toml                                     |   7 +-
 requirements-test.txt                              |   4 +-
 setup.py                                           |   7 +-
 tests/test_es_client.py                            |  47 +++++-
 tests/test_es_client_compat.py                     | 159 +++++++++++++++++++++
```

## Test plan

- [x] ES suite (81 tests) green against `elasticsearch` 7.17.13, 8.19.3 and 9.4.1
- [x] New compat tests fail against the pre-fix client code on 8.x/9.x, so they catch the regression they claim to
- [x] `pip install .[elasticsearch]` resolves in an environment already holding an 8.x or 9.x client (the reported `ResolutionImpossible`)
- [x] Full suite green apart from pre-existing `test_snowflake_client` failures unrelated to this change
- [x] Black clean on the new test file; markdownlint clean on touched docs
- [ ] CI `es-compat` matrix green on all three majors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Elasticsearch clients 7.17 through 9.x.
  - Improved request handling to preserve caller-provided search bodies and apply result limits consistently.
  - Added compatibility coverage across supported Elasticsearch versions.

- **Documentation**
  - Updated installation and integration guides with supported versions, configuration notes, and compatibility guidance.
  - Added an architectural decision record documenting the supported client range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->