### PR TITLE
refactor(timezone)!: read zone data from stdlib zoneinfo, drop pytz

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,7 +40,7 @@ This is `nui-python-shared-utils`, a Python package providing production-ready u
 - **JWT Authentication** (`jwt_auth.py`) - RS256 token validation for API Gateway Lambdas (uses `rsa` package)
 - **LLM Helper** (`llm.py`) - Generic Anthropic (Claude) client plumbing: API-key/Bedrock auth, forced tool-use call, text call (uses `anthropic`)
 - **Error Handling** (`error_handler.py`) - Retry patterns with exponential backoff
-- **Timezone Utils** (`timezone.py`) - Timezone conversion and formatting utilities
+- **Timezone Utils** (`timezone.py`) - Timezone conversion and formatting utilities (stdlib `zoneinfo`)
 
 ### Optional Dependencies
 
@@ -52,6 +52,7 @@ The package uses optional extras to minimize Lambda bundle size:
 - `jwt` - RS256 JWT validation (`rsa` package)
 - `snowflake` - Pure-Python Snowflake SQL API client (`snowflake-sql-api`)
 - `llm` - Anthropic (Claude) client helper (`anthropic[bedrock]`, both API-key and Bedrock IAM auth)
+- `timezone` - `tzdata`, for minimal images with no system IANA database (Alpine, distroless)
 - `all` - All integrations
 - `dev` - Development and testing tools
 

--- a/docs/decisions/ADR-008-stdlib-zoneinfo-over-pytz.md
+++ b/docs/decisions/ADR-008-stdlib-zoneinfo-over-pytz.md
@@ -1,0 +1,89 @@
+# ADR-008: Zone data from stdlib `zoneinfo`, not a bundled `pytz`
+
+**Status**: Proposed
+**Date**: 2026-07-27
+
+## Context
+
+Every install of this package pays for its base dependencies, whatever the consumer imports.
+`pytz` sat in that base set for two modules (`timezone.py`, `slack_formatter.py`), so a Lambda
+that wanted only the logging contract or the metrics helper still shipped it.
+
+The cost is not the code. `pytz` bundles its own copy of the Olson/IANA database (0.86 MB of a
+1.0 MB installed package, measured on `pytz==2025.2`), and that copy is redundant on
+every interpreter this package supports: `requires-python = ">=3.9"`, and `zoneinfo` has been in
+the standard library since 3.9, reading the system database that Linux, macOS, and the AWS Lambda
+runtimes all ship.
+
+`pytz` also carries an API predating PEP 495. Its zones must be attached through
+`tz.localize(dt)` rather than `datetime(..., tzinfo=tz)`, because a bare `pytz` zone object
+defaults to whatever offset was in effect at the start of that zone's records: attaching
+`pytz.timezone("Pacific/Auckland")` to a 2024 datetime yields the 1868 LMT offset of `+11:39`.
+`ZoneInfo` resolves the offset from the datetime itself, giving `+13:00`, so the direct
+constructor form is correct.
+
+## Decision
+
+Zone data comes from stdlib `zoneinfo`. `pytz` is dropped from the base dependencies and from
+the package entirely, with no compatibility shim.
+
+- `NZ_TZ`, `AUS_TZ`, `US_EAST_TZ`, `US_WEST_TZ`, `EUR_TZ` are `ZoneInfo` instances.
+- `pytz.UTC.localize(dt)` becomes `dt.replace(tzinfo=timezone.utc)`.
+- `slack_formatter` imports `NZ_TZ` from `timezone` rather than constructing its own zone, so
+  one module owns the zone constants.
+- The package's own conversions take UTC input, so no code path here has to resolve an ambiguous
+  wall time. Callers attaching a zone to a naive local time do, and the default differs from
+  `pytz`: `datetime(..., tzinfo=NZ_TZ)` uses `fold=0`, the first (still-daylight) occurrence of a
+  repeated hour, where `pytz.localize()` defaulted to `is_dst=False`, the second. `fold=1`
+  reproduces the old default. `TestAmbiguousWallTimes` pins both sides.
+
+Zone data availability is handled where it actually differs by platform, rather than by shipping
+a database to everyone:
+
+- `tzdata>=2023.3; platform_system == "Windows"` in the base dependencies. Windows ships no
+  system database; POSIX consumers resolve the marker to nothing and install neither package.
+- A `[timezone]` extra (`tzdata`) for minimal images (Alpine, distroless) that carry no
+  `/usr/share/zoneinfo`. No environment marker can detect those, so it is opt-in.
+
+## Alternatives considered
+
+- **Move `pytz` into an extra, keep the code as-is.** Fixes the unconditional cost and nothing
+  else: consumers of `timezone.py` still install a redundant database, and the `localize()` API
+  stays. Rejected as half the change for most of the churn.
+- **Keep `pytz` and accept the base-dependency cost.** The status quo. Rejected: the package
+  exists to be bundled into Lambdas, where the base set is the floor nobody can opt out of.
+- **Depend on `tzdata` unconditionally instead of the system database.** Trades one bundled
+  database for another (a 0.35 MB wheel) on platforms that already have one. Rejected; the
+  marker plus the extra cover the platforms that genuinely need it.
+- **Ship a `localize()`-compatible wrapper for the exported zone constants.** Rejected: it
+  preserves a pre-PEP-495 idiom indefinitely to spare a one-line call-site change.
+
+## Consequences
+
+- A base install drops ~1 MB and one runtime dependency. Nothing in the package imports a
+  third-party timezone library.
+- **Breaking for code importing the zone constants from `nui_shared_utils.timezone`.**
+  `NZ_TZ.localize(dt)` is gone; use `datetime(..., tzinfo=NZ_TZ)` or `dt.replace(tzinfo=NZ_TZ)`,
+  with `fold=1` where the old `is_dst=False` default mattered. `NZ_TZ.zone` is now `NZ_TZ.key`.
+  The top-level package exports only `nz_time` / `format_nz_time`, whose behaviour is unchanged,
+  so consumers going through `nui_shared_utils` see nothing.
+- Attaching a zone at construction is now correct rather than a bug, so the sharp edge that made
+  `localize()` mandatory is gone.
+- `slack_formatter.format_nz_time()` called with no argument is fixed as a side effect. It built
+  a naive `datetime.utcnow()` and handed it to `astimezone()`, which reads a naive datetime as
+  *local* time: right on a UTC host, an hour or thirteen out anywhere else. It now starts from an
+  aware UTC now, so the result no longer depends on the host clock's zone.
+- On an image with no system database, `import nui_shared_utils.timezone` raises
+  `ZoneInfoNotFoundError` instead of silently working. That is a louder failure than `pytz` gave,
+  and the `[timezone]` extra is the fix.
+- Zone data tracks the host, not a pinned package version. DST rule changes arrive with system
+  updates instead of a dependency bump, which is the desired direction for long-lived Lambda
+  images but does mean a stale base image carries stale rules.
+
+## Load-bearing premises (supersede triggers)
+
+- **The interpreter floor stays at 3.9+.** `zoneinfo` is stdlib from 3.9. A drop below that
+  would need `backports.zoneinfo`, at which point the calculus changes.
+- **Target runtimes ship a system IANA database.** True of Linux, macOS, and the AWS Lambda
+  runtimes today. If the primary deployment target became one that does not, `tzdata` belongs in
+  the base dependencies unconditionally and this ADR's marker split is obsolete.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -30,3 +30,4 @@ Keep each ADR under two pages. Longer than that means it is a plan, not an ADR.
 | [005](ADR-005-explicit-secrets-manager-region.md) | Resolve the Secrets Manager region explicitly (session, then env); no hidden default, fail loud | Proposed | 2026-07-13 |
 | [006](ADR-006-snowflake-sql-api-client.md) | Snowflake access via the pure-Python SQL API client, not the native connector | Proposed | 2026-07-13 |
 | [007](ADR-007-elasticsearch-client-version-range.md) | Support elasticsearch-py 7.17, 8.x and 9.x from one call shape | Proposed | 2026-07-27 |
+| [008](ADR-008-stdlib-zoneinfo-over-pytz.md) | Zone data from stdlib `zoneinfo`, not a bundled `pytz` | Proposed | 2026-07-27 |

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -34,6 +34,9 @@ pip install nui-python-shared-utils[database]
 # JWT authentication only
 pip install nui-python-shared-utils[jwt]
 
+# Zone data, for minimal images with no system IANA database (Alpine, distroless)
+pip install nui-python-shared-utils[timezone]
+
 # All integrations
 pip install nui-python-shared-utils[all]
 
@@ -59,9 +62,13 @@ pip install -e .[dev]
 ### Core Dependencies (Always Installed)
 
 - `boto3` - AWS SDK for Python
-- `pytz` - Timezone handling
 - `click` - CLI framework
 - `pyyaml` - YAML configuration parsing
+- `tzdata` - Zone data, **Windows only** (installed via an environment marker)
+
+Timezone conversion uses the standard library's `zoneinfo`, which reads the
+system IANA database. Linux, macOS, and the AWS Lambda runtimes all ship one,
+so nothing extra is installed there.
 
 ### Optional Dependencies by Extra
 
@@ -85,6 +92,18 @@ pip install -e .[dev]
 #### jwt
 
 - `rsa>=4.9` - Pure Python RSA implementation (~100KB, no C extensions)
+
+#### timezone
+
+- `tzdata>=2023.3` - Zone data for images that carry no system IANA database
+
+  Only needed on a minimal image (Alpine, distroless) where `/usr/share/zoneinfo`
+  is absent, which no environment marker can detect. Without it, importing
+  `nui_shared_utils.timezone` raises `ZoneInfoNotFoundError`. Windows already
+  gets `tzdata` from the core dependencies.
+
+  `[all]` covers the integrations and does **not** include this; on a minimal
+  image ask for it by name (`[all,timezone]`).
 
 #### dev
 

--- a/nui_shared_utils/slack_formatter.py
+++ b/nui_shared_utils/slack_formatter.py
@@ -4,8 +4,9 @@ Provides a builder pattern for creating Slack Block Kit messages.
 """
 
 from typing import Dict, List, Any, Optional, Union
-from datetime import datetime, timedelta
-import pytz
+from datetime import datetime, timedelta, timezone
+
+from .timezone import NZ_TZ
 
 # Severity emoji mapping
 SEVERITY_EMOJI = {"critical": "🚨", "warning": "⚠️", "info": "ℹ️", "success": "✅", "error": "❌"}
@@ -42,25 +43,23 @@ def format_number(value: Union[int, float], decimals: int = 0) -> str:
 def format_nz_time(dt: Optional[datetime] = None) -> str:
     """Format datetime in NZ timezone."""
     if dt is None:
-        dt = datetime.utcnow()
+        dt = datetime.now(timezone.utc)
     elif not dt.tzinfo:
-        dt = dt.replace(tzinfo=pytz.UTC)
+        dt = dt.replace(tzinfo=timezone.utc)
 
-    nz_tz = pytz.timezone("Pacific/Auckland")
-    nz_time = dt.astimezone(nz_tz)
+    nz_time = dt.astimezone(NZ_TZ)
     return nz_time.strftime("%I:%M %p %Z")
 
 
 def format_date_range(start: datetime, end: datetime) -> str:
     """Format a date range in NZ timezone."""
-    nz_tz = pytz.timezone("Pacific/Auckland")
     if not start.tzinfo:
-        start = start.replace(tzinfo=pytz.UTC)
+        start = start.replace(tzinfo=timezone.utc)
     if not end.tzinfo:
-        end = end.replace(tzinfo=pytz.UTC)
+        end = end.replace(tzinfo=timezone.utc)
 
-    start_nz = start.astimezone(nz_tz)
-    end_nz = end.astimezone(nz_tz)
+    start_nz = start.astimezone(NZ_TZ)
+    end_nz = end.astimezone(NZ_TZ)
 
     if start_nz.date() == end_nz.date():
         return f"{start_nz.strftime('%b %d')} {start_nz.strftime('%I:%M %p')} - {end_nz.strftime('%I:%M %p %Z')}"

--- a/nui_shared_utils/timezone.py
+++ b/nui_shared_utils/timezone.py
@@ -1,17 +1,21 @@
 """
 Timezone utilities for multi-timezone handling (NZ primary, AUS/US/EUR secondary).
+
+Zone data comes from the standard library's ``zoneinfo``, which reads the system
+IANA database. Environments without one (Windows, minimal images such as Alpine)
+need the ``tzdata`` package: `pip install nui-python-shared-utils[timezone]`.
 """
 
 from datetime import datetime, timezone
-import pytz
-from typing import List, Tuple, Optional
+from typing import List, Optional, Tuple
+from zoneinfo import ZoneInfo
 
 # Supported timezones
-NZ_TZ = pytz.timezone("Pacific/Auckland")  # Primary timezone
-AUS_TZ = pytz.timezone("Australia/Sydney")
-US_EAST_TZ = pytz.timezone("US/Eastern")
-US_WEST_TZ = pytz.timezone("US/Pacific")
-EUR_TZ = pytz.timezone("Europe/London")
+NZ_TZ = ZoneInfo("Pacific/Auckland")  # Primary timezone
+AUS_TZ = ZoneInfo("Australia/Sydney")
+US_EAST_TZ = ZoneInfo("US/Eastern")
+US_WEST_TZ = ZoneInfo("US/Pacific")
+EUR_TZ = ZoneInfo("Europe/London")
 
 
 def nz_time(utc_dt: Optional[datetime] = None) -> datetime:
@@ -28,7 +32,7 @@ def nz_time(utc_dt: Optional[datetime] = None) -> datetime:
         utc_dt = datetime.now(timezone.utc)
 
     if utc_dt.tzinfo is None:
-        utc_dt = pytz.UTC.localize(utc_dt)
+        utc_dt = utc_dt.replace(tzinfo=timezone.utc)
 
     return utc_dt.astimezone(NZ_TZ)
 
@@ -66,7 +70,7 @@ def format_multi_timezone(dt: Optional[datetime] = None, primary_tz: str = "nz",
         dt = datetime.now(timezone.utc)
 
     if dt.tzinfo is None:
-        dt = pytz.UTC.localize(dt)
+        dt = dt.replace(tzinfo=timezone.utc)
 
     # Timezone mapping
     tz_map = {"nz": NZ_TZ, "aus": AUS_TZ, "us_east": US_EAST_TZ, "us_west": US_WEST_TZ, "eur": EUR_TZ}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,11 @@ classifiers = [
 keywords = ["aws", "lambda", "utilities", "slack", "elasticsearch", "monitoring", "serverless", "python", "shared"]
 dependencies = [
     "boto3>=1.20.0",
-    "pytz>=2021.3",
     "click>=8.0.0",
     "pyyaml>=6.0",
+    # Zone data for stdlib `zoneinfo`, which otherwise reads the system IANA
+    # database. Windows ships none; POSIX systems do, so they pay nothing here.
+    "tzdata>=2023.3; platform_system == 'Windows'",
 ]
 
 [project.optional-dependencies]
@@ -48,6 +50,10 @@ powertools = [
     "coloredlogs>=15.0",
 ]
 jwt = ["rsa>=4.9"]
+# Zone data for images that carry no system IANA database (Alpine, distroless).
+# Not expressible as an environment marker, hence an opt-in extra. Unneeded on
+# a normal Linux/macOS install or an AWS Lambda runtime.
+timezone = ["tzdata>=2023.3"]
 # Pinned to the published PyPI release (no direct-URL deps, PyPI rejects those
 # on upload). Kept out of `all`: opt-in.
 snowflake = [
@@ -75,11 +81,13 @@ dev = [
     "mypy>=0.990",
     "boto3-stubs[essential]>=1.20.0",
     "types-PyYAML>=6.0.0",
-    "types-pytz>=2021.3.0",
     "twine>=4.0.0",
     "build>=0.8.0",
     "rsa>=4.9",
     "cryptography>=41.0.0",
+    # Lets the test suite exercise the zone-data fallback on a host that has a
+    # system IANA database; see the [timezone] extra.
+    "tzdata>=2023.3",
     "snowflake-sql-api>=0.1.1,<0.2.0",
     "anthropic[bedrock]>=0.45.0,<1.0.0",
 ]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -15,7 +15,6 @@ isort>=5.12.0
 
 # Type stubs for mypy
 boto3-stubs[secretsmanager,cloudwatch]>=1.28.0
-types-pytz>=2023.3.0
 types-PyYAML>=6.0.0
 
 # Optional dependencies for testing
@@ -27,6 +26,10 @@ psycopg2-binary>=2.9.0
 slack-sdk>=3.19.0
 rsa>=4.9
 cryptography>=41.0.0
+
+# Zone data (see pyproject [timezone] extra). Installed so the "no system IANA
+# database" path is exercised on a CI runner that has one.
+tzdata>=2023.3
 
 # snowflake adapter (tag pin; see pyproject [snowflake] extra)
 snowflake-sql-api @ git+https://github.com/hampsterx/snowflake-sql-api.git@v0.1.1

--- a/setup.py
+++ b/setup.py
@@ -44,9 +44,11 @@ setup(
     },
     install_requires=[
         "boto3>=1.20.0",
-        "pytz>=2021.3",
         "click>=8.0.0",
         "pyyaml>=6.0",
+        # Zone data for stdlib `zoneinfo`, which otherwise reads the system IANA
+        # database. Windows ships none; POSIX systems do, so they pay nothing.
+        "tzdata>=2023.3; platform_system == 'Windows'",
     ],
     extras_require={
         # Client majors 7.17, 8.x and 9.x are all supported: es_client sends one
@@ -60,6 +62,10 @@ setup(
             "coloredlogs>=15.0",
         ],
         "jwt": ["rsa>=4.9"],
+        # Zone data for images that carry no system IANA database (Alpine,
+        # distroless). Not expressible as an environment marker, hence an
+        # opt-in extra. Unneeded on Linux/macOS or an AWS Lambda runtime.
+        "timezone": ["tzdata>=2023.3"],
         # Pinned to the published PyPI release (no direct-URL deps, PyPI rejects
         # those on upload). Kept out of "all": opt-in.
         "snowflake": [
@@ -87,11 +93,13 @@ setup(
             "mypy>=0.990",
             "boto3-stubs[essential]>=1.20.0",
             "types-PyYAML>=6.0.0",
-            "types-pytz>=2021.3.0",
             "twine>=4.0.0",
             "build>=0.8.0",
             "rsa>=4.9",
             "cryptography>=41.0.0",
+            # Lets the test suite exercise the zone-data fallback on a host that
+            # has a system IANA database; see the "timezone" extra.
+            "tzdata>=2023.3",
             "anthropic[bedrock]>=0.45.0,<1.0.0",
         ],
     },

--- a/tests/test_es_query_builder.py
+++ b/tests/test_es_query_builder.py
@@ -4,8 +4,7 @@ Tests for es_query_builder module.
 
 import pytest
 from unittest.mock import patch
-from datetime import datetime, timedelta
-import pytz
+from datetime import datetime, timedelta, timezone
 
 from nui_shared_utils.es_query_builder import (
     ESQueryBuilder,
@@ -34,8 +33,8 @@ class TestESQueryBuilder:
     def test_with_time_range_datetime_objects(self):
         """Test adding time range with datetime objects."""
         builder = ESQueryBuilder()
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         result = builder.with_time_range(start_time, end_time)
 
@@ -396,8 +395,8 @@ class TestPrebuiltQueries:
     def test_build_error_rate_query(self):
         """Test building error rate query."""
         service = "connect-order"
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         query = build_error_rate_query(service, start_time, end_time, interval="10m")
 
@@ -438,8 +437,8 @@ class TestPrebuiltQueries:
     def test_build_top_errors_query(self):
         """Test building top errors query."""
         service = "connect-auth"
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         query = build_top_errors_query(service, start_time, end_time, top_n=20)
 
@@ -471,8 +470,8 @@ class TestPrebuiltQueries:
     def test_build_response_time_query(self):
         """Test building response time query."""
         service = "connect-product"
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         query = build_response_time_query(service, start_time, end_time)
 
@@ -504,8 +503,8 @@ class TestPrebuiltQueries:
     def test_build_service_volume_query(self):
         """Test building service volume query."""
         services = ["connect-order", "connect-auth", "connect-product"]
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         query = build_service_volume_query(services, start_time, end_time)
 
@@ -535,8 +534,8 @@ class TestPrebuiltQueries:
 
     def test_build_user_activity_query(self):
         """Test building user activity query."""
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         query = build_user_activity_query(start_time, end_time, user_field="user.email")
 
@@ -577,11 +576,11 @@ class TestPrebuiltQueries:
     @patch("nui_shared_utils.es_query_builder.datetime")
     def test_build_pattern_detection_query_with_start_time(self, mock_datetime):
         """Test building pattern detection query with start time."""
-        mock_utcnow = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        mock_utcnow = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
         mock_datetime.utcnow.return_value = mock_utcnow
 
         pattern = "database timeout"
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
 
         query = build_pattern_detection_query(pattern, field="error.message", start_time=start_time)
 
@@ -614,7 +613,7 @@ class TestPrebuiltQueries:
     @patch("nui_shared_utils.es_query_builder.datetime")
     def test_build_pattern_detection_query_without_start_time(self, mock_datetime):
         """Test building pattern detection query without start time."""
-        mock_utcnow = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        mock_utcnow = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
         mock_datetime.utcnow.return_value = mock_utcnow
 
         pattern = "connection failed"
@@ -637,8 +636,8 @@ class TestPrebuiltQueries:
     def test_build_tender_participant_query(self):
         """Test building tender participant query."""
         tender_id = "tender-12345"
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         query = build_tender_participant_query(tender_id, start_time, end_time)
 
@@ -691,8 +690,8 @@ class TestPrebuiltQueries:
     def test_build_error_rate_query_default_interval(self):
         """Test error rate query with default interval."""
         service = "connect-order"
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         query = build_error_rate_query(service, start_time, end_time)
 
@@ -702,8 +701,8 @@ class TestPrebuiltQueries:
     def test_build_top_errors_query_default_top_n(self):
         """Test top errors query with default top_n."""
         service = "connect-auth"
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         query = build_top_errors_query(service, start_time, end_time)
 
@@ -712,8 +711,8 @@ class TestPrebuiltQueries:
 
     def test_build_user_activity_query_default_user_field(self):
         """Test user activity query with default user field."""
-        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start_time = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end_time = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         query = build_user_activity_query(start_time, end_time)
 

--- a/tests/test_slack_formatter.py
+++ b/tests/test_slack_formatter.py
@@ -2,9 +2,11 @@
 Tests for slack_formatter module.
 """
 
+import os
+import subprocess
+import sys
 from unittest.mock import patch
-from datetime import datetime, timedelta
-import pytz
+from datetime import datetime, timedelta, timezone
 
 from nui_shared_utils.slack_formatter import (
     format_currency,
@@ -19,6 +21,20 @@ from nui_shared_utils.slack_formatter import (
     SEVERITY_EMOJI,
     STATUS_EMOJI,
 )
+
+# Run in its own process so the host clock's zone can be set for the call.
+_NO_ARG_NZ_TIME_SCRIPT = """
+from datetime import datetime, timezone
+from nui_shared_utils.slack_formatter import format_nz_time
+from nui_shared_utils.timezone import NZ_TZ
+
+fmt = "%I:%M %p %Z"
+before = datetime.now(timezone.utc)
+got = format_nz_time()
+after = datetime.now(timezone.utc)
+expected = {t.astimezone(NZ_TZ).strftime(fmt) for t in (before, after)}
+print(f"match={got in expected}")
+"""
 
 
 class TestFormatFunctions:
@@ -71,7 +87,7 @@ class TestFormatFunctions:
 
     def test_format_nz_time_with_datetime(self):
         """Test NZ time formatting with provided datetime."""
-        utc_time = datetime(2023, 6, 15, 12, 30, 0, tzinfo=pytz.UTC)
+        utc_time = datetime(2023, 6, 15, 12, 30, 0, tzinfo=timezone.utc)
         result = format_nz_time(utc_time)
 
         # Should contain time in NZ timezone format
@@ -87,10 +103,29 @@ class TestFormatFunctions:
         assert "AM" in result or "PM" in result
         assert "NZST" in result or "NZDT" in result
 
+    def test_format_nz_time_no_argument_ignores_the_host_clock_zone(self):
+        """The no-arg result must be the same wherever the process runs.
+
+        Run under ``TZ=Pacific/Auckland``: a naive "now" handed to ``astimezone()``
+        would be read as local time and come back unshifted (13 hours off), so this
+        only passes if the value starts out UTC-aware. Bracketing the call with two
+        UTC reads keeps it stable across a minute boundary.
+        """
+        result = subprocess.run(
+            [sys.executable, "-c", _NO_ARG_NZ_TIME_SCRIPT],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=30,
+            env={**os.environ, "TZ": "Pacific/Auckland"},
+        )
+
+        assert "match=True" in result.stdout
+
     def test_format_date_range_same_day(self):
         """Test date range formatting for same day."""
-        start = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end = datetime(2023, 6, 15, 14, 0, 0, tzinfo=pytz.UTC)
+        start = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2023, 6, 15, 14, 0, 0, tzinfo=timezone.utc)
 
         result = format_date_range(start, end)
 
@@ -101,8 +136,8 @@ class TestFormatFunctions:
 
     def test_format_date_range_different_days(self):
         """Test date range formatting for different days."""
-        start = datetime(2023, 6, 15, 10, 0, 0, tzinfo=pytz.UTC)
-        end = datetime(2023, 6, 16, 14, 0, 0, tzinfo=pytz.UTC)
+        start = datetime(2023, 6, 15, 10, 0, 0, tzinfo=timezone.utc)
+        end = datetime(2023, 6, 16, 14, 0, 0, tzinfo=timezone.utc)
 
         result = format_date_range(start, end)
 

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -2,9 +2,30 @@
 Tests for timezone module.
 """
 
-from datetime import datetime, timezone
+import os
+import subprocess
+import sys
+import textwrap
+from datetime import datetime, timedelta, timezone
 from unittest.mock import patch
+
+import pytest
+
 from nui_shared_utils.timezone import nz_time, format_nz_time, NZ_TZ
+
+
+def _run(script: str, env_overrides: dict = None) -> str:
+    """Execute ``script`` in a fresh Python interpreter and return stdout."""
+    env = {**os.environ, **(env_overrides or {})}
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(script)],
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+        env=env,
+    )
+    return result.stdout.strip()
 
 
 class TestNzTime:
@@ -21,7 +42,7 @@ class TestNzTime:
         # So 10:00 UTC should be 23:00 NZDT
         assert result.hour == 23
         assert result.day == 30
-        assert result.tzinfo.zone == "Pacific/Auckland"
+        assert result.tzinfo.key == "Pacific/Auckland"
 
     def test_nz_time_with_naive_datetime(self):
         """Test converting naive datetime to NZ time (assumes UTC)."""
@@ -33,7 +54,7 @@ class TestNzTime:
         # Should treat as UTC and convert to NZ
         assert result.hour == 23
         assert result.day == 30
-        assert result.tzinfo.zone == "Pacific/Auckland"
+        assert result.tzinfo.key == "Pacific/Auckland"
 
     def test_nz_time_no_argument(self):
         """Test getting current NZ time."""
@@ -46,7 +67,7 @@ class TestNzTime:
 
         assert result.hour == 23
         assert result.day == 30
-        assert result.tzinfo.zone == "Pacific/Auckland"
+        assert result.tzinfo.key == "Pacific/Auckland"
 
     def test_nz_time_winter_time(self):
         """Test NZ time during winter (NZST - UTC+12)."""
@@ -58,18 +79,18 @@ class TestNzTime:
         # 10:00 UTC should be 22:00 NZST
         assert result.hour == 22
         assert result.day == 15
-        assert result.tzinfo.zone == "Pacific/Auckland"
+        assert result.tzinfo.key == "Pacific/Auckland"
 
     def test_nz_time_with_already_nz_datetime(self):
         """Test passing datetime already in NZ timezone."""
-        nz_dt = NZ_TZ.localize(datetime(2024, 1, 30, 15, 0, 0))
+        nz_dt = datetime(2024, 1, 30, 15, 0, 0, tzinfo=NZ_TZ)
 
         result = nz_time(nz_dt)
 
         # Should preserve the time
         assert result.hour == 15
         assert result.day == 30
-        assert result.tzinfo.zone == "Pacific/Auckland"
+        assert result.tzinfo.key == "Pacific/Auckland"
 
 
 class TestFormatNzTime:
@@ -127,22 +148,130 @@ class TestFormatNzTime:
         assert result == "2024-07-15 22:00:00 NZST"
 
 
+class TestNoThirdPartyTimezoneDependency:
+    """Zone data comes from stdlib ``zoneinfo``; nothing here may pull in ``pytz``.
+
+    Run in a fresh interpreter so an import from elsewhere in the suite cannot
+    mask a regression. ``pytz`` is no longer a declared dependency, so this also
+    fails loudly if it creeps back into a module that ships in the base install.
+    """
+
+    def test_timezone_module_does_not_import_pytz(self):
+        output = _run("""
+            import sys
+            import nui_shared_utils.timezone  # noqa: F401
+            print(f"pytz={'pytz' in sys.modules}")
+            """)
+        assert "pytz=False" in output
+
+    def test_slack_formatter_does_not_import_pytz(self):
+        output = _run("""
+            import sys
+            import nui_shared_utils.slack_formatter  # noqa: F401
+            print(f"pytz={'pytz' in sys.modules}")
+            """)
+        assert "pytz=False" in output
+
+
+class TestZoneDataSources:
+    """Where ``zoneinfo`` reads its database from, and how it fails without one.
+
+    ``TZPATH`` is fixed at interpreter start from ``PYTHONTZPATH``, so each case
+    needs its own process. Emptying it simulates an image with no
+    ``/usr/share/zoneinfo`` (Alpine, distroless, Windows).
+    """
+
+    def test_zone_resolves_from_tzdata_when_system_database_is_absent(self):
+        """The ``[timezone]`` extra (``tzdata``) must be a sufficient zone source.
+
+        This is the documented fix for a minimal image, so it needs to hold
+        without a system database rather than be asserted in the docs alone.
+        """
+        pytest.importorskip("tzdata", reason="tzdata is the [timezone] extra; not installed here")
+
+        output = _run(
+            """
+            from zoneinfo import TZPATH
+            from nui_shared_utils.timezone import NZ_TZ, nz_time
+            from datetime import datetime, timezone
+            print(f"tzpath_empty={TZPATH == ()}")
+            print(f"key={NZ_TZ.key}")
+            print(nz_time(datetime(2024, 1, 30, 10, 0, 0, tzinfo=timezone.utc)).strftime("offset=%z %Z"))
+            """,
+            env_overrides={"PYTHONTZPATH": ""},
+        )
+        assert "tzpath_empty=True" in output
+        assert "key=Pacific/Auckland" in output
+        assert "offset=+1300 NZDT" in output
+
+    def test_missing_zone_data_fails_loudly(self):
+        """With no system database and no ``tzdata``, import raises rather than guessing."""
+        output = _run(
+            """
+            import sys
+
+            class _BlockTzdata:
+                def find_spec(self, name, path=None, target=None):
+                    if name == "tzdata" or name.startswith("tzdata."):
+                        raise ImportError("tzdata blocked for this test")
+                    return None
+
+            sys.meta_path.insert(0, _BlockTzdata())
+            try:
+                import nui_shared_utils.timezone  # noqa: F401
+                print("result=imported")
+            except Exception as exc:
+                print(f"result={type(exc).__name__}")
+            """,
+            env_overrides={"PYTHONTZPATH": ""},
+        )
+        assert "result=ZoneInfoNotFoundError" in output
+
+
+class TestAmbiguousWallTimes:
+    """``fold`` decides which side of a DST fall-back an ambiguous wall time lands on.
+
+    ``ZoneInfo`` defaults to ``fold=0`` (the first, still-daylight occurrence).
+    Pinned here because the zone constants are public and invite direct
+    construction, where the choice is silent and an hour wide.
+    """
+
+    def test_fold_selects_the_repeated_hour(self):
+        # NZ daylight time ends 2024-04-07 03:00 NZDT -> 02:00 NZST, so 02:30 happens twice.
+        ambiguous = datetime(2024, 4, 7, 2, 30, 0)
+
+        first = ambiguous.replace(tzinfo=NZ_TZ)  # fold=0
+        second = ambiguous.replace(tzinfo=NZ_TZ, fold=1)
+
+        assert first.strftime("%Z") == "NZDT"
+        assert first.utcoffset().total_seconds() == 13 * 3600
+        assert second.strftime("%Z") == "NZST"
+        assert second.utcoffset().total_seconds() == 12 * 3600
+
+    def test_utc_input_is_never_ambiguous(self):
+        """The module's own conversions take UTC, so they sidestep the fold question."""
+        utc_dt = datetime(2024, 4, 6, 13, 30, 0, tzinfo=timezone.utc)
+
+        assert nz_time(utc_dt).strftime("%H:%M %Z") == "02:30 NZDT"
+        assert nz_time(utc_dt + timedelta(hours=1)).strftime("%H:%M %Z") == "02:30 NZST"
+
+
 class TestTimezoneConstants:
     """Tests for timezone constants."""
 
     def test_nz_tz_constant(self):
         """Test that NZ_TZ is properly configured."""
-        assert NZ_TZ.zone == "Pacific/Auckland"
+        assert NZ_TZ.key == "Pacific/Auckland"
 
         # Test DST transitions
         # Summer time (NZDT - UTC+13)
         summer = datetime(2024, 1, 15, 12, 0, 0)
-        summer_nz = NZ_TZ.localize(summer)
+        summer_nz = summer.replace(tzinfo=NZ_TZ)
         assert summer_nz.strftime("%Z") == "NZDT"
         assert summer_nz.utcoffset().total_seconds() == 13 * 3600
 
         # Winter time (NZST - UTC+12)
         winter = datetime(2024, 7, 15, 12, 0, 0)
-        winter_nz = NZ_TZ.localize(winter)
+        winter_nz = winter.replace(tzinfo=NZ_TZ)
         assert winter_nz.strftime("%Z") == "NZST"
         assert winter_nz.utcoffset().total_seconds() == 12 * 3600


### PR DESCRIPTION
## Summary

- `pytz` is no longer installed. It was a base dependency but only two modules imported it, so every install carried its bundled Olson database (0.86 MB of a 1.0 MB installed package) whether or not the consumer touched a timezone helper. Python 3.9+ ships `zoneinfo`, which reads the system IANA database, making the bundled copy redundant on every supported interpreter.
- `timezone.py` and `slack_formatter.py` now use `zoneinfo.ZoneInfo`. `slack_formatter` takes `NZ_TZ` from `timezone` instead of building its own copy, so one module owns the zone constants.
- Zone data is handled per platform rather than shipped to everyone: `tzdata` is a base dependency behind a `platform_system == "Windows"` marker (POSIX consumers install nothing), plus a new `[timezone]` extra for minimal images (Alpine, distroless) that no environment marker can detect.
- `slack_formatter.format_nz_time()` called with no argument is fixed as a side effect. It handed a naive `datetime.utcnow()` to `astimezone()`, which reads naive input as *local* time: correct on a UTC host, 12 hours out on an NZ-local one.
- Rationale, alternatives, and the supersede triggers are in [ADR-008](docs/decisions/ADR-008-stdlib-zoneinfo-over-pytz.md).

Closes #36.

## Backwards compatibility

**Breaking for code importing the zone constants from `nui_shared_utils.timezone`** (`NZ_TZ`, `AUS_TZ`, `US_EAST_TZ`, `US_WEST_TZ`, `EUR_TZ`). They are `ZoneInfo` instances now, not `pytz` zones:

| Before | After |
|--------|-------|
| `NZ_TZ.localize(dt)` | `datetime(..., tzinfo=NZ_TZ)` or `dt.replace(tzinfo=NZ_TZ)` |
| `NZ_TZ.zone` | `NZ_TZ.key` |

One semantic difference worth knowing when migrating a `localize()` call: for a wall time inside a DST fall-back, `pytz.localize()` defaulted to `is_dst=False` (the second, standard-time occurrence) while `ZoneInfo` defaults to `fold=0` (the first, still-daylight one). Pass `fold=1` where the old default mattered. `TestAmbiguousWallTimes` pins both sides.

Everything reached through the top-level package is unaffected: `nui_shared_utils` exports only `nz_time` and `format_nz_time`, whose behaviour is unchanged.

## Review

Internal: clean. External (Codex, GLM-5.2 agentic): 4 applied (fold semantics documented and tested, host-TZ regression test, zone-data source tests, `[all]` caveat in the docs), 2 noted below.

## Changes

```
 AGENTS.md                                          |   3 +-
 docs/decisions/ADR-008-stdlib-zoneinfo-over-pytz.md |  89 ++++++++++++
 docs/decisions/README.md                           |   1 +
 docs/getting-started/installation.md               |  21 ++-
 nui_shared_utils/slack_formatter.py                |  21 ++-
 nui_shared_utils/timezone.py                       |  22 +--
 pyproject.toml                                     |  12 +-
 requirements-test.txt                              |   5 +-
 setup.py                                           |  12 +-
 tests/test_es_query_builder.py                     |  49 ++++---
 tests/test_slack_formatter.py                      |  49 ++++++-
 tests/test_timezone.py                             | 149 +++++++++++++++++++--
 12 files changed, 364 insertions(+), 69 deletions(-)
```

## Test plan

- [x] Full suite green with `import pytz` blocked at the meta_path level, so nothing shipped in the base install can quietly depend on it
- [x] New: `tzdata` alone resolves zones with an empty `TZPATH` (the documented fix for a minimal image), and `ZoneInfoNotFoundError` is raised with neither source
- [x] New: `fold` selection across the NZ DST fall-back, both sides pinned
- [x] New: `format_nz_time()` with no argument is independent of the host clock's zone (verified it fails against the previous implementation under `TZ=Pacific/Auckland`, 02:14 AM vs 02:14 PM)
- [x] New: neither `timezone` nor `slack_formatter` imports `pytz`, checked in a fresh interpreter
- [x] Wheel builds; metadata carries `tzdata>=2023.3; platform_system == "Windows"` and `Provides-Extra: timezone`, with no `pytz`
- [x] `black --check` clean on the touched files; `mypy` unchanged (10 pre-existing errors, none in the touched modules)
- [ ] `test_snowflake_client.py` failures are pre-existing locally (`snowflake-sql-api` not installed) and identical on unmodified `master`; CI installs it

## Follow-ups (not in this PR)

- `redirect/pyproject.toml` does not forward the new `timezone` extra. It also does not forward `snowflake` or `llm`, and it is pinned at `version = "2.0.0"` and already published, so bringing its extras current needs its own change plus a republish.
- The zone constants keep the legacy aliases `US/Eastern` and `US/Pacific`. Both ship in the PyPI `tzdata` wheel and in every mainstream system build, so nothing breaks; `America/New_York` / `America/Los_Angeles` would hold up better against a database built without the backward links, at the cost of changing public constant values.