### PR TITLE
ci: scope workflow token to contents:read, pin 8.x compat points

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main, master, develop ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Test Python ${{ matrix.python-version }}
@@ -82,8 +85,11 @@ jobs:
       matrix:
         # Every major the [elasticsearch] extra allows. The ES tests drive the
         # real client with a stubbed transport, so a call shape that a major
-        # stops accepting fails here.
-        elasticsearch-version: ['7.17.*', '8.*', '9.*']
+        # stops accepting fails here. 8.x is pinned at three points because the
+        # client handles `body=` differently across the major: 8.0-8.11 route it
+        # through the parameter-rewriting fallback, 8.12+ take it as a declared
+        # parameter, and a bare `8.*` only ever resolves to the latter.
+        elasticsearch-version: ['7.17.*', '8.0.*', '8.11.*', '8.*', '9.*']
 
     steps:
     - uses: actions/checkout@v5

--- a/docs/decisions/ADR-007-elasticsearch-client-version-range.md
+++ b/docs/decisions/ADR-007-elasticsearch-client-version-range.md
@@ -40,7 +40,9 @@ shape all three majors accept: `size` folded into a **copy** of the caller's bod
 
 `tests/test_es_client_compat.py` drives the real client with a stubbed transport (no server),
 so an incompatible call shape fails as a test rather than in a consumer's Lambda. The CI
-`es-compat` matrix runs it against 7.17, 8.x and 9.x.
+`es-compat` matrix runs it against 7.17, 8.x and 9.x, pinning 8.x at three points (8.0, 8.11
+and latest) because the client routes `body=` through the parameter-rewriting fallback up to
+8.11 and takes it as a declared parameter from 8.12 on.
 
 The `<10` ceiling is the untested next major, not a known incompatibility.
 


### PR DESCRIPTION
## Summary

- Add a top-level `permissions: contents: read` block so the workflow token carries read-only scope instead of whatever the repository default grants. No job needs write: the auto-format step commits locally and never pushes, and every checkout already sets `persist-credentials: false`.
- Pin the `es-compat` matrix at `8.0.*` and `8.11.*` alongside the existing `8.*`. elasticsearch-py routes `body=` through its parameter-rewriting fallback up to 8.11 and takes it as a declared parameter from 8.12 on, so a bare `8.*` always resolves to the later path and leaves the fallback untested.
- Record the 8.x split in ADR-007 so the matrix shape has a stated reason rather than looking like redundant pins.

## Review

External: Codex (agentic, repo-aware) and GLM-5.2 both returned no significant findings.

## Changes

```
.github/workflows/ci.yml                                     | 10 ++++++++--
docs/decisions/ADR-007-elasticsearch-client-version-range.md |  4 +++-
```

## Test plan

- [x] `test_es_client.py` + `test_es_client_compat.py` + `test_es_query_builder.py` pass against `elasticsearch==8.0.1` (81 passed) and `elasticsearch==8.11.1` (81 passed)
- [x] Compat file also verified against `elasticsearch==8.12.0`, the version where `body` becomes a declared parameter
- [x] Workflow YAML parses; matrix resolves to the 5 intended pins
- [ ] CI green on the new `8.0.*` and `8.11.*` jobs